### PR TITLE
set Content-Type header to application/json after self.index() 

### DIFF
--- a/eea/facetednavigation/browser/app/counter.py
+++ b/eea/facetednavigation/browser/app/counter.py
@@ -57,13 +57,13 @@ class FacetedQueryCounter(object):
     @ramcache(cacheCounterKeyFacetedNavigation,
               dependencies=['eea.facetednavigation'])
     def __call__(self, *args, **kwargs):
+        # Calling self.index() will set cache headers for varnish
+        self.index()
+
         if self.request:
             kwargs.update(self.request.form)
             self.request.response.setHeader('Content-Type',
                                             'application/json; charset=utf-8')
-
-        # Calling self.index() will set cache headers for varnish
-        self.index()
 
         cid = kwargs.pop('cid', None)
         if not cid:


### PR DESCRIPTION
self.index() sets the content-type to text/html, rendering the json unusable when Diazo is enabled due to it ended up being wrapped with &lt;html&gt; tag.

this patch reorders to the code to set Content-Type after calling self.index()
