### PR TITLE
added basic support for collective.solr

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,8 @@ Changelog
 
 7.8.dev0 - (unreleased)
 -----------------------
+* Play nice with collective.solr
+  [tomgross]
 
 7.7 - (2015-02-03)
 ------------------

--- a/eea/facetednavigation/browser/app/query.py
+++ b/eea/facetednavigation/browser/app/query.py
@@ -91,7 +91,14 @@ class FacetedQueryHandler(object):
             widget = criteria.widget(cid=cid)
             widget = widget(self.context, self.request, criterion)
 
-            query.update(widget.query(kwargs))
+            widget_query = widget.query(kwargs)
+            if getattr(widget, 'faceted_field', False):
+                widget_index = widget.data.get('index', '')
+                if 'facet.field' in query and widget_index not in query['facet.field']:
+                    query['facet.field'].append(widget_index)
+                else:
+                    query['facet.field'] = [widget_index]
+            query.update(widget_query)
 
             # Handle language widgets
             if criterion.get('index', '') == 'Language':

--- a/eea/facetednavigation/widgets/widget.py
+++ b/eea/facetednavigation/widgets/widget.py
@@ -375,7 +375,6 @@ class CountableWidget(Widget):
         """ Intersect results
         """
         res = {}
-        res[""] = res['all'] = len(brains)
         try:
             # Use facet count of solr, if it is installed and used
             pkg_resources.get_distribution('collective.solr')
@@ -396,6 +395,7 @@ class CountableWidget(Widget):
                     # no facet counts were returned. we exit anyway because
                     # zcatalog methods throw an error on solr responses
                     pass
+                res[""] = res['all'] = len(brains)
                 return res
             else:
                 # this is handled by the zcatalog. see below
@@ -421,6 +421,7 @@ class CountableWidget(Widget):
             return res
 
         brains = IISet(brain.getRID() for brain in brains)
+        res[""] = res['all'] = len(brains)
         for value in sequence:
             if not value:
                 res[value] = len(brains)


### PR DESCRIPTION
This patch allows getting facet counts from collective.solr, if it is installed.
It assumes all Countable Widgets are facetable by solr (by the *faceted_field* property on the class). This probably has to be finetuned a bit.