### PR TITLE
infinite loop fix

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,8 @@ Changelog
 
 8.2.dev0 - (unreleased)
 -----------------------
+* Bug fix: Infinite loop of javascript spinner after Browser refresh. 
+  [karalics] PR #69
 
 8.1 - (2015-07-06)
 ------------------

--- a/eea/facetednavigation/widgets/widget.py
+++ b/eea/facetednavigation/widgets/widget.py
@@ -206,7 +206,8 @@ class Widget(ATWidget):
                 value = translate(message, domain=domain, context=self.request)
                 if value != message:
                     return value
-            return message
+            else:
+                return message
 
     def cleanup(self, string):
         """ Quote string
@@ -407,7 +408,7 @@ class CountableWidget(Widget):
                         res[normalized_value] = num
                     else:
                         unicode_value = value.decode('utf-8')
-                    res[unicode_value] = num
+                        res[unicode_value] = num
             else:
                 # no facet counts were returned. we exit anyway because
                 # zcatalog methods throw an error on solr responses


### PR DESCRIPTION
Plone 5: After changing configuration or refreshing browser with a search result, the javascript spinner in  the Portal Type Widget keeps looping. The search result doesn't show up.
