### PR TITLE
Read default value of widget from the request.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,12 @@ Changelog
 8.8.dev0 - (unreleased)
 -----------------------
 
+* Read default value of widget from the request.  Fallback to the
+  default set on the widget.  For example, if you have a faceted text
+  widget that searches in the SearchableText index, and you have
+  ``?SearchableText=fun`` in the url, then the widget will show
+  ``fun`` as default value.  [maurits]
+
 8.7 - (2015-12-07)
 ------------------
 * Change: Removed CSRF security quickfix for tests
@@ -761,4 +767,3 @@ Changelog
 1.0 (2009-10-30)
 ----------------
 * Initial release
-

--- a/eea/facetednavigation/tests/test_widgets.py
+++ b/eea/facetednavigation/tests/test_widgets.py
@@ -2,6 +2,7 @@
 """
 from eea.facetednavigation.tests.base import FacetedTestCase
 from eea.facetednavigation.widgets.widget import CountableWidget
+from eea.facetednavigation.widgets.widget import Widget
 
 
 class DummySolrResponse(dict):
@@ -37,3 +38,29 @@ class CountableWidgetTestCase(FacetedTestCase):
         dummyresponse = DummySolrResponse({'tags': {'foo': 10, 'bar': 7}})
         self.assertEqual(widget.count(dummyresponse),
                          {'': 1, 'all': 1, u'bar': 7, u'foo': 10})
+
+
+class WidgetTestCase(FacetedTestCase):
+    """ Test
+    """
+
+    def afterSetUp(self):
+        """ Setup
+        """
+        self.request = self.app.REQUEST
+
+    def test_default_from_widget(self):
+        """ Get default value from widget.
+        """
+        data = {'index': 'SearchableText', 'default': 'fun'}
+        self.request.form['otherindex'] = 'serious fun'
+        widget = Widget(self.portal, self.request, data=data)
+        self.assertEqual(widget.default, 'fun')
+
+    def test_default_from_request(self):
+        """ Get default value from request.
+        """
+        data = {'index': 'SearchableText', 'default': 'fun'}
+        self.request.form['SearchableText'] = 'serious fun'
+        widget = Widget(self.portal, self.request, data=data)
+        self.assertEqual(widget.default, 'serious fun')

--- a/eea/facetednavigation/widgets/widget.py
+++ b/eea/facetednavigation/widgets/widget.py
@@ -173,11 +173,16 @@ class Widget(ATWidget):
         """
         # Language widget has custom behaviour so be sure you keep
         # this in your widget
-        if self.data.get('index', None) == 'Language':
+        index = self.data.get('index', None)
+        if index == 'Language':
             language_widget = queryMultiAdapter((self, self.context),
                                                 ILanguageWidgetAdapter)
             if language_widget:
                 return language_widget.default
+        # Take value from request parameter, for example ?SearchableText=test.
+        from_request = self.request.form.pop(index, None)
+        if from_request is not None:
+            return from_request
         return self.data.get('default', None)
 
     def query(self, form):


### PR DESCRIPTION
Fallback to the default set on the widget.

For example, if you have a faceted text widget that searches in the SearchableText index, and you have ``?SearchableText=fun`` in the url, then the widget will show ``fun`` as default value.

This pull request may help for this issue: https://github.com/eea/eea.facetednavigation/issues/73

I intend to use this in a Diazo theme to let the portal search box point to a faceted navigation page.