### PR TITLE
fix for the "Plone Portlet" widget

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
   widget that searches in the SearchableText index, and you have
   ``?SearchableText=fun`` in the url, then the widget will show
   ``fun`` as default value.  [maurits]
+* Get the correct template object for "Plone Portlet" widgets [skurfer]
 
 8.7 - (2015-12-07)
 ------------------

--- a/eea/facetednavigation/widgets/portlet/widget.py
+++ b/eea/facetednavigation/widgets/portlet/widget.py
@@ -53,7 +53,7 @@ class Widget(AbstractWidget):
         path, mode = macro_list
         path = path.split('/')
         try:
-            template = self.context.restrictedTraverse(path)
+            template = self.context.restrictedTraverse(path).index
             if template:
                 return template.macros[mode]
         except Exception:


### PR DESCRIPTION
I spent some time in the debugger and found that the `.index` property pointed to the object necessary to get this working.