### PR TITLE
Use select2 for the autocomplete widget

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -94,6 +94,15 @@ Hide facets criteria if there is only one page of results.
 
 Default: **disabled** (*starting with version 5.2*)
 
+Autocomplete widget
+-------------------
+For the autocomplete widget to work, you need to have select2 javascript library installed. You can install it by selecting "EEA jQuery - Select2" profile in ZMI portal_setup/Import and clicking `Import all steps` button.
+
+To include a specific select2 locale, French for instance, you can add a resource `++resource++select2/select2_locale_fr.js` in portal_javascripts (Plone 4). It needs to be after the select2.min.js resource. (You need eea.jquery 8.7 minimum)
+
+You can add a new autocomplete source by registering a IAutocompleteSuggest browser view, you can see an example in
+`eea/facetednavigation/tests/autocomplete.py` and `eea/facetednavigation/tests/autocomplete.zcml`
+
 Extra
 =====
 You can extend faceted navigation functionality by installing the following

--- a/README.txt
+++ b/README.txt
@@ -96,8 +96,6 @@ Default: **disabled** (*starting with version 5.2*)
 
 Autocomplete widget
 -------------------
-For the autocomplete widget to work, you need to have select2 javascript library installed. You can install it by selecting "EEA jQuery - Select2" profile in ZMI portal_setup/Import and clicking `Import all steps` button.
-
 To include a specific select2 locale, French for instance, you can add a resource `++resource++select2/select2_locale_fr.js` in portal_javascripts (Plone 4). It needs to be after the select2.min.js resource. (You need eea.jquery 8.7 minimum)
 
 You can add a new autocomplete source by registering a IAutocompleteSuggest browser view, you can see an example in

--- a/buildouts/plone4/dev.cfg
+++ b/buildouts/plone4/dev.cfg
@@ -1,0 +1,9 @@
+[buildout]
+extends = buildout.cfg
+
+[instance]
+zcml = eea.facetednavigation.tests-autocomplete
+
+[versions]
+zc.buildout = 
+setuptools =

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,10 @@ Changelog
 
 8.8.dev0 - (unreleased)
 -----------------------
+* Change: The autocomplete widget now uses select2 instead of
+  jquery.autocomplete. It supports mono value or multi values.
+  This release registers select2 javascript library in portal_javascripts.
+  [vincentfretin]
 
 * Read default value of widget from the request.  Fallback to the
   default set on the widget.  For example, if you have a faceted text

--- a/eea/facetednavigation/locales/bg/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/bg/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Съдържание списък"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Контролирайте обхвата на yearsdisplayed на година падащото: или роднина години днес (-нн: + NN), по отношение на избраната година (в-нн: в + NN), абсолютна (NNNN: НННН), или комбинации от тези формати (NNNN:-нн)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Брой резултати"
 
@@ -273,7 +277,7 @@ msgstr "Изключване на правилните портлети"
 msgid "Disable smart facets hiding"
 msgstr "Забрана интелигентни аспекти крие"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Покажи броя на резултатите до всяка опция"
 
@@ -284,6 +288,14 @@ msgstr "Покажи джаджите в раздел"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Покажи джаджите в раздел."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "ETAG стойност"
 msgid "Export"
 msgstr "Износ "
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Фасетиран критерии"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Фасетиран глобални настройки"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Фасетиран търсене поддръжка"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Фасетиран настройки"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Скриване на филтри"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Скриване на елементи с нулев резултат"
 
@@ -681,7 +722,7 @@ msgstr "Главната папка"
 msgid "Save"
 msgstr "Запази"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Търсене"
@@ -708,6 +749,10 @@ msgstr "Bereich"
 msgid "Select"
 msgstr "избор"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Избиране на всички елементи"
@@ -728,7 +773,7 @@ msgstr "Смарт аспекти скривалище сега е деакти�
 msgid "Smart facets hiding is now enabled"
 msgstr "Смарт аспекти скривалището е активиран"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Тал Изразяване"
 msgid "Text field"
 msgstr "Текст областта"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Тема, за да се използва с тази джаджа"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Тази опция работи само ако е разрешен \"преброяване резултати\""
 
@@ -831,7 +876,7 @@ msgstr "Потребителския интерфейс Календар год�
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Махнете отметката от това квадратче, ако не искате Скрий / Покажи критерии характеристика е разрешена за тази джаджа"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "вчера"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "всички елементи"
@@ -888,7 +933,7 @@ msgstr "всички елементи"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "в текущите резултати"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/bg/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/bg/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Портален тип"
 
 msgid "Sort on"
 msgstr "Сортирай по"
-

--- a/eea/facetednavigation/locales/cs/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/cs/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Obsah stránek"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Měnit rozsah yearsdisplayed v roce drop-down: buď vzhledem k dnešním roku (-nn: + nn), vzhledem k právě vybrané rok c-nn: C + nn), absolutní (nnnn: nnnn), nebo kombinace z těchto formátů (nnnn:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Počítat výsledky"
 
@@ -273,7 +277,7 @@ msgstr "Zakázat správné portlety"
 msgid "Disable smart facets hiding"
 msgstr "Zakázat inteligentní aspekty skrývá"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Zobrazí počet výsledků v blízkosti každé volby"
 
@@ -284,6 +288,14 @@ msgstr "Zobrazit ovládací prvek v sekci"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Zobrazit ovládací prvek v sekci."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "ETAG hodnotu"
 msgid "Export"
 msgstr "Exportovat"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Tváří kritéria"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Tváří globální nastavení"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Tváří hledání povoleny"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Nastavení tváří"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Skrýt filtry"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Skrýt položky s nulovým výsledkům"
 
@@ -681,7 +722,7 @@ msgstr "Kořenová složka"
 msgid "Save"
 msgstr "Uložit"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Vyhledávání"
@@ -708,6 +749,10 @@ msgstr "Část"
 msgid "Select"
 msgstr "Výběr"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Výběr všech položek"
@@ -728,7 +773,7 @@ msgstr "Inteligentní aspekty skrývání je nyní zakázáno"
 msgid "Smart facets hiding is now enabled"
 msgstr "Inteligentní aspekty skrývání je nyní povoleno"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Tal Expression"
 msgid "Text field"
 msgstr "Textové pole"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Téma pro použití s tímto widgetu"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Tato možnost funguje pouze tehdy, pokud se sčítají výsledky je povolena"
 
@@ -831,7 +876,7 @@ msgstr "UI Kalendář let pohybuje"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Zrušte zaškrtnutí tohoto políčka, pokud nechcete zobrazit / skrýt kritéria mají povoleno na tomto prvku"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "včera"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "všechny položky"
@@ -888,7 +933,7 @@ msgstr "všechny položky"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "v současných výsledcích"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/cs/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/cs/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Portálového typu"
 
 msgid "Sort on"
 msgstr "Seřadit"
-

--- a/eea/facetednavigation/locales/da/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/da/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: 2013-10-03 11:56 +0100\n"
 "Last-Translator: Thomas Clement Mogensen <tmog@headnet.dk>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Indholdsliste"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Indstil den årrække der skal kunne vælges fra - enten i forhold til indeværende år (-nn:+nn), i forhold til det valgte år (c-nn:c+nn), eller helt frit (nnnn:nnnn). Du kan også bruge en kombination af disse formater, f.eks. (nnnn:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Tæl resultater"
 
@@ -273,7 +277,7 @@ msgstr "Slå højre-kolonne portletter fra"
 msgid "Disable smart facets hiding"
 msgstr "Slå intelligent visning af facetter fra"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Vis antallet af resultater ud for hver valgmulighed"
 
@@ -284,6 +288,14 @@ msgstr "Vis widget i sektionen"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Vis widget i sektionen."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "ETAG værdi"
 msgid "Export"
 msgstr "Eksportér"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Facetteret søgning"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Globale indstillinger for facetter"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Facetteret søgning slået til"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Indstillinger for facetter"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr "Skjul muligheden Alle"
 msgid "Hide filters"
 msgstr "Skjul filtre"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Skjul elementer med nul resultater"
 
@@ -681,7 +722,7 @@ msgstr "Rodmappe"
 msgid "Save"
 msgstr "Gem"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Søg"
@@ -708,6 +749,10 @@ msgstr "Sektion"
 msgid "Select"
 msgstr "Vælg"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Vælg alle emner"
@@ -728,7 +773,7 @@ msgstr "Intelligent visning af facetter er nu slået far"
 msgid "Smart facets hiding is now enabled"
 msgstr "Intelligent visning af facetter er nu slået til"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr "Sortér efter antal"
 
@@ -779,7 +824,7 @@ msgstr "TAL-udtryk"
 msgid "Text field"
 msgstr "Tekstfelt"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Tema, der skal bruges med denne widget"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Denne indstilling gælder kun, hvis 'Tæl resultater' er slået til"
 
@@ -831,7 +876,7 @@ msgstr "År, der skal kunne vælges"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Fjern markeringen i dette felt, hvis du ikke ønsker skjul/vis kriterier funktionaliteten på denne widget"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr "Sorter efter antal resultater"
 
@@ -879,7 +924,7 @@ msgstr "I går"
 msgid "all"
 msgstr "alle"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "alle emner"
@@ -888,7 +933,7 @@ msgstr "alle emner"
 msgid "any"
 msgstr "enhver"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "i nuværende resultater"
@@ -901,7 +946,6 @@ msgstr "match"
 msgid "match any/all filters bellow"
 msgstr "match en/alle af nedenstående filtre"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/da/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/da/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Indholdstype"
 
 msgid "Sort on"
 msgstr "Sortér efter"
-

--- a/eea/facetednavigation/locales/de/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/de/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eea.facetednavigation\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: 2011-05-23 13:46+0100\n"
 "Last-Translator: Jens W. Klein <jens@bluedynamics.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -149,7 +153,7 @@ msgstr "Inhaltsauflistung"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Steuerung der Bereich von yearsdisplayed im Jahr Drop-down: entweder relativ zu heutigen Jahr (-nn: + nn), bezogen auf den aktuell gewählten Jahr (c-nn: c + nn) absolut (nnnn: nnnn) oder Kombinationen dieser Formate (nnnn:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Zähle Ergebnisse"
 
@@ -291,7 +295,7 @@ msgid "Disable smart facets hiding"
 msgstr "Deaktiviert die Smartcard Facetten versteckt"
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Zeige die Anzahl der Ergebnisse nahe bei dieser Option"
 
@@ -304,6 +308,14 @@ msgstr "Zeige Widget in Sektion"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Zeige Widget in Abschnitt."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -360,15 +372,40 @@ msgstr "ETag-Wert"
 msgid "Export"
 msgstr "Export"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Faceted-Kriterium"
 
 #. Default: ""
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Globale Einstellungen für Faceted"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -390,6 +427,10 @@ msgstr "Faceted Suche aktiviert"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Faceted Einstellungen"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -444,7 +485,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Ausblenden Filter"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Verstecke Einträge ohne Ergebnisse"
 
@@ -728,7 +769,7 @@ msgstr "Root-Ordner"
 msgid "Save"
 msgstr "Speichern"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Suche"
@@ -757,6 +798,10 @@ msgstr "Sektion"
 msgid "Select"
 msgstr "Auswahl"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #. Default: ""
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
@@ -778,7 +823,7 @@ msgstr "Smart Facetten Versteck ist nun deaktiviert"
 msgid "Smart facets hiding is now enabled"
 msgstr "Smart Facetten Versteck ist nun aktiviert"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -833,7 +878,7 @@ msgstr "Tal Expression"
 msgid "Text field"
 msgstr "Text Feld"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -842,7 +887,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Theme mit diesem Widget verwendet werden"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Diese Option funktioniert nur zusammen mit 'Zähle Ergebnisse'."
 
@@ -891,7 +936,7 @@ msgstr "UI Kalender Jahre reichen"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Deaktivieren Sie dieses Kontrollkästchen, wenn Sie nicht wollen, hide / show Kriterien aktiviert auf diesem Widget"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -944,7 +989,7 @@ msgstr "Gestern"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "Alle Einträge"
@@ -953,7 +998,7 @@ msgstr "Alle Einträge"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "in aktuellen Ergebnissen"
@@ -966,7 +1011,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/de/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/de/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Portal-Type"
 
 msgid "Sort on"
 msgstr "Sortieren nach"
-

--- a/eea/facetednavigation/locales/eea.pot
+++ b/eea/facetednavigation/locales/eea.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -91,6 +91,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -145,7 +149,7 @@ msgstr ""
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr ""
 
@@ -276,7 +280,7 @@ msgstr ""
 msgid "Disable smart facets hiding"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr ""
 
@@ -286,6 +290,14 @@ msgstr ""
 
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
 msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
@@ -341,13 +353,38 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr ""
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
+msgstr ""
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
 msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
@@ -368,6 +405,10 @@ msgstr ""
 
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
 msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
@@ -420,7 +461,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr ""
 
@@ -684,7 +725,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr ""
@@ -711,6 +752,10 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr ""
@@ -731,7 +776,7 @@ msgstr ""
 msgid "Smart facets hiding is now enabled"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -782,7 +827,7 @@ msgstr ""
 msgid "Text field"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -790,7 +835,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr ""
 
@@ -834,7 +879,7 @@ msgstr ""
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -882,7 +927,7 @@ msgstr ""
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr ""
@@ -891,7 +936,7 @@ msgstr ""
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr ""
@@ -904,7 +949,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/el/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/el/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Λίστα περιεχομένων"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Ελέγξτε το φάσμα των yearsdisplayed το έτος drop-down: είτε σε σχέση με το έτος σημερινή (-nn: + nn), σε σχέση με το επιλεγμένο έτους (γ-nn: C + nn), απόλυτη (nnnn: nnnn), ή συνδυασμούς από αυτές τις μορφές (nnnn:-NN)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Μετρήστε τα αποτελέσματα"
 
@@ -273,7 +277,7 @@ msgstr "Απενεργοποίηση δικαίωμα συστατικά στο�
 msgid "Disable smart facets hiding"
 msgstr "Απενεργοποίηση έξυπνη όψεις κρύβονται"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Εμφάνιση του αριθμού των αποτελεσμάτων δίπλα σε κάθε επιλογή"
 
@@ -284,6 +288,14 @@ msgstr "Εμφάνιση widget στο τμήμα"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Εμφάνιση widget στο τμήμα."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "Τιμή ETag"
 msgid "Export"
 msgstr "Εξαγωγή"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Πολύπλευρη κριτήρια"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Πολύπλευρη καθολικές ρυθμίσεις"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Πολύπλευρη δυνατότητα αναζήτησης"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Πολύπλευρη ρυθμίσεις"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Απόκρυψη φίλτρων"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Απόκρυψη στοιχείων με μηδενικά αποτελέσματα"
 
@@ -681,7 +722,7 @@ msgstr "Φακέλου ρίζας"
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Αναζήτηση"
@@ -708,6 +749,10 @@ msgstr "Τμήμα"
 msgid "Select"
 msgstr "Επιλογή"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Επιλογή όλων των στοιχείων"
@@ -728,7 +773,7 @@ msgstr "Smart απόκρυψη πτυχές είναι τώρα εκτός λε�
 msgid "Smart facets hiding is now enabled"
 msgstr "Smart απόκρυψη πτυχές είναι τώρα ενεργοποιημένη"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Tal Έκφραση"
 msgid "Text field"
 msgstr "Πεδίο Κείμενο"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Θέμα που πρέπει να χρησιμοποιούνται με αυτό το μαραφέτι"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Αυτή η επιλογή δουλεύει μόνο αν «τα αποτελέσματα μετράνε» είναι ενεργοποιημένη"
 
@@ -831,7 +876,7 @@ msgstr "UI Ημερολογιακά έτη κυμαίνονται"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Αποεπιλέξτε αυτό το πλαίσιο, αν δεν θέλετε απόκρυψη / εμφάνιση κριτήρια διαθέτουν τη δυνατότητα σε αυτό το μαραφέτι"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "χτες"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "Όλα τα αντικείμενα"
@@ -888,7 +933,7 @@ msgstr "Όλα τα αντικείμενα"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "σε τρέχοντα αποτελέσματα"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/el/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/el/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Πύλη τύπου"
 
 msgid "Sort on"
 msgstr "Ταξινόμηση με"
-

--- a/eea/facetednavigation/locales/en/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/en/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: 2012-04-25 17:20+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr ""
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr ""
 
@@ -273,7 +277,7 @@ msgstr ""
 msgid "Disable smart facets hiding"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr ""
 
@@ -283,6 +287,14 @@ msgstr ""
 
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
 msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
@@ -338,13 +350,38 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr ""
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
+msgstr ""
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
 msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
@@ -365,6 +402,10 @@ msgstr ""
 
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
 msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr ""
 
@@ -681,7 +722,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr ""
@@ -708,6 +749,10 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr ""
@@ -728,7 +773,7 @@ msgstr ""
 msgid "Smart facets hiding is now enabled"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr ""
 msgid "Text field"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr ""
 
@@ -831,7 +876,7 @@ msgstr ""
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr ""
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr ""
@@ -888,7 +933,7 @@ msgstr ""
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr ""
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/en/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/en/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr ""
 
 msgid "Sort on"
 msgstr ""
-

--- a/eea/facetednavigation/locales/es/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/es/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eea.facetednavigation\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: 2012-11-27 16:24+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: ES <LL@li.org>\n"
@@ -90,6 +90,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #. Default: ""
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
@@ -154,7 +158,7 @@ msgid "Control the range of yearsdisplayed in the year drop-down: either relativ
 msgstr "Controlar el rango de años mostrados en el desplegable de años: relativo al año actual (-nn: + nn), relativo al año seleccionado actualmente (c-nn: c+nn), absoluto (nnnn:nnnn), o combinaciones de estos formatos (nnnn:-nn)."
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Contar resultados"
 
@@ -297,7 +301,7 @@ msgid "Disable smart facets hiding"
 msgstr "Desactivar esconder facetas inteligentes "
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Mostrar el número de resultados junto a cada opción"
 
@@ -310,6 +314,14 @@ msgstr "Mostrar widget en sección"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Mostrar widget en sección."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -366,15 +378,40 @@ msgstr "Valor del ETag"
 msgid "Export"
 msgstr "Exportar"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Criterios de facetas"
 
 #. Default: ""
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Configuración global de facetas"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -396,6 +433,10 @@ msgstr "Búsqueda facetada habilitada"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Ajustes de facetas"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -452,7 +493,7 @@ msgid "Hide filters"
 msgstr "Ocultar filtros"
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Ocultar elementos con cero resultados"
 
@@ -737,7 +778,7 @@ msgstr "Carpeta raíz"
 msgid "Save"
 msgstr "Guardar"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Buscar"
@@ -767,6 +808,10 @@ msgstr "Sección"
 msgid "Select"
 msgstr "Seleccionable"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #. Default: ""
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
@@ -788,7 +833,7 @@ msgstr "Esconder facetas inteligentes está desactivado"
 msgid "Smart facets hiding is now enabled"
 msgstr "Esconder facetas inteligentes está activado"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -843,7 +888,7 @@ msgstr "Expresión TAL"
 msgid "Text field"
 msgstr "Campo de Texto"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -852,7 +897,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Tema para ser utilizado con este widget"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Esta opción sólo funciona si 'contar resultados' está activado"
 
@@ -900,7 +945,7 @@ msgstr "UI Calendar rango de años"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Desmarque esta casilla si no desea ocultar/mostrar los criterios habilitados en este widget"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -954,7 +999,7 @@ msgstr "Ayer"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "todos los elementos"
@@ -963,7 +1008,7 @@ msgstr "todos los elementos"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "en los resultados actuales"
@@ -976,7 +1021,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/es/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/es/LC_MESSAGES/plone.po
@@ -33,4 +33,3 @@ msgstr "Tipo de elemento"
 
 msgid "Sort on"
 msgstr "Ordenar por"
-

--- a/eea/facetednavigation/locales/et/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/et/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Sisuloendis"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Kontrollida erinevaid yearsdisplayed aastal rippmenüüst: kas võrreldes tänapäeva aasta (-nn: + NN), võrreldes valitud aasta (c-nn: c + NN), absoluutne (nnnn: nnnn), või nende kombinatsioone neid formaate (nnnn:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Krahv tulemusi"
 
@@ -273,7 +277,7 @@ msgstr "Keela õigus Mooduli"
 msgid "Disable smart facets hiding"
 msgstr "Keela smart tahke peidus"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Kuva tulemuste arv peaaegu iga võimalust"
 
@@ -284,6 +288,14 @@ msgstr "Kuva vidina punktis"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Kuva vidina punktis."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "ETAG väärtus"
 msgid "Export"
 msgstr "Eksport"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Lihvitud kriteeriumid"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Lihvitud globaalsed seadistused"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Lihvitud otsing lubatud"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Lihvitud seaded"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Peida filtrid"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Peida esemed null tulemusi"
 
@@ -681,7 +722,7 @@ msgstr "Juurkaustade"
 msgid "Save"
 msgstr "Salvesta"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Otsing"
@@ -708,6 +749,10 @@ msgstr "Osa"
 msgid "Select"
 msgstr "Vali"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Kõik teemad"
@@ -728,7 +773,7 @@ msgstr "Smart tahke peidus on nüüd blokeeritud"
 msgid "Smart facets hiding is now enabled"
 msgstr "Smart tahke peidus on nüüd lubatud"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Tal Expression"
 msgid "Text field"
 msgstr "Tekstiväli"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Teema, mida kasutatakse selle vidina"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "See valik toimib ainult siis, kui 'count tulemused' on sisse lülitatud"
 
@@ -831,7 +876,7 @@ msgstr "UI Calendar aastat ulatuda"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Puhasta see ruut, kui te ei soovi peida / näita kriteeriumid funktsioon on sisse lülitatud selle vidina"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "eile"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "kõik teemad"
@@ -888,7 +933,7 @@ msgstr "kõik teemad"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "praeguste tulemuste"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/et/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/et/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Portaali tüüpi"
 
 msgid "Sort on"
 msgstr "Sorteerida"
-

--- a/eea/facetednavigation/locales/eu/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/eu/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eea.facetednavigation\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: 2013-11-19 08:24+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: eu <eu@li.org>\n"
@@ -89,6 +89,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #. Default: ""
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
@@ -152,7 +156,7 @@ msgid "Control the range of yearsdisplayed in the year drop-down: either relativ
 msgstr "Urteen aukeraketa menuko urteen tartea kontrolatu: uneko urtearen tartea (-nn:+nn), aukeratutako urtearekiko erlatibioa (c-nn:c+nn), absolutua  (nnnn:nnnn) edo esandako formatuen arteko konbinazioak (nnnn:-nn)."
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Emaitza kopurua erakutsi"
 
@@ -295,7 +299,7 @@ msgid "Disable smart facets hiding"
 msgstr "Sailkapen argiak ezkutatzea desaktibatu"
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Aukera bakoitzaren ondoan balio hori duen elementu-kopurua erakutsi"
 
@@ -308,6 +312,14 @@ msgstr "Widgeta atal baten erakutsi"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Widgeta atala baten erakutsi"
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -365,15 +377,40 @@ msgstr "Etag balioa"
 msgid "Export"
 msgstr "Esportatu"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Sailkapen-irizpideak"
 
 #. Default: ""
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Sailkapenen konfigurazioa orokorra"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -395,6 +432,10 @@ msgstr "Sailkapen bidezko bilaketa aktibatuta"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Sailkapenaren ezarpenak"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -451,7 +492,7 @@ msgid "Hide filters"
 msgstr "Filtroak ezkutatu"
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Ezkutatu emaitzarik ez duten elementuak"
 
@@ -736,7 +777,7 @@ msgstr "Erroa"
 msgid "Save"
 msgstr "Gorde"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Bilatu"
@@ -766,6 +807,10 @@ msgstr "Atala"
 msgid "Select"
 msgstr "Aukeraketa-kutxa"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #. Default: ""
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
@@ -787,7 +832,7 @@ msgstr "Sailkapen argiak ezkutatzea desaktibatuta"
 msgid "Smart facets hiding is now enabled"
 msgstr "Sailkapen argiak ezkutatzea aktibatuta"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr "Kontagarri direnen arabera ordenatu"
 
@@ -842,7 +887,7 @@ msgstr "Tal espresioa"
 msgid "Text field"
 msgstr "Testu-eremua"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -851,7 +896,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Widget honekin erabili beharreko itxura"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Aukera honek \"Emaitza kopurua erakutsi\" aktibatuta dagoenean bakarrik balio du."
 
@@ -900,7 +945,7 @@ msgstr "Egutegiko urte-sorta"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Desaktibatu kutxa hau ez baduzu widget honetan erakutsi/ezkutatu aukera agertzea nahi."
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr "Emaitzen kontagailua erabili ordenatzeko"
 
@@ -954,7 +999,7 @@ msgstr "Atzo"
 msgid "all"
 msgstr "guztiak"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "elementu guztiak"
@@ -963,7 +1008,7 @@ msgstr "elementu guztiak"
 msgid "any"
 msgstr "edozein"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "uneko elementuetan"
@@ -976,7 +1021,6 @@ msgstr "bat-etorri"
 msgid "match any/all filters bellow"
 msgstr "Beheko filtro guztiak/edozein bat-etorri"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/eu/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/eu/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Elementu-mota"
 
 msgid "Sort on"
 msgstr "Ordenazioa"
-

--- a/eea/facetednavigation/locales/fi/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/fi/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Sisällön listalle"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Ohjaa eri yearsdisplayed vuonna avattavasta: joko suhteessa nykypäivän vuoteen (-nn: + nn), suhteessa valittuun vuoteen (c-nn: c + nn), absoluuttinen (nnnn: nnnn), tai niiden yhdistelmiä seuraavista muodoista (nnnn:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Laske tulokset"
 
@@ -273,7 +277,7 @@ msgstr "Poista oikea portlet"
 msgid "Disable smart facets hiding"
 msgstr "Poista älykäs puolta piilossa"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Näytä tulosten määrä lähes jokaisen vaihtoehdon"
 
@@ -284,6 +288,14 @@ msgstr "Näytä widget kohdassa"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Näytä widget kohdassa."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "ETAG arvo"
 msgid "Export"
 msgstr "Vie"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Särmikkäät kriteerit"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Särmikkäät yleisasetukset"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Särmikkäät haku päällä"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Särmikkäät asetukset"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Piilota suodattimet"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Piilota kohteita nolla tulosta"
 
@@ -681,7 +722,7 @@ msgstr "Root-kansioon"
 msgid "Save"
 msgstr "Tallenna"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Haku"
@@ -708,6 +749,10 @@ msgstr "Osa"
 msgid "Select"
 msgstr "Valita"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Valitse kaikki"
@@ -728,7 +773,7 @@ msgstr "Smart puolta piilossa on nyt poistettu käytöstä"
 msgid "Smart facets hiding is now enabled"
 msgstr "Smart puolta piilossa on nyt käytössä"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Tal Expression"
 msgid "Text field"
 msgstr "Tekstikenttä"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Teema tulee käyttää tämä vekotin"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Tämä toiminto toimii vain, jos \"count tuloksia\" on käytössä"
 
@@ -831,7 +876,7 @@ msgstr "UI Kalenterivuodet vaihtelevat"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Poista tämä valinta, jos et halua hide / show kriteerit ominaisuus käytössä tämä vekotin"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "eilen"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "kaikki kohteet"
@@ -888,7 +933,7 @@ msgstr "kaikki kohteet"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "Lyhytaikaisten tulokset"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/fi/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/fi/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Portal tyyppi"
 
 msgid "Sort on"
 msgstr "Lajitella"
-

--- a/eea/facetednavigation/locales/fr/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/fr/LC_MESSAGES/eea.po
@@ -3,19 +3,21 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
-"PO-Revision-Date: 2012-04-26 17:32+0200\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
+"PO-Revision-Date: 2016-02-23 12:06+0100\n"
+"Last-Translator: Vincent Fretin <vincent.fretin@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "Language-Code: en\n"
 "Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: eea\n"
+"Language: fr\n"
+"X-Generator: Poedit 1.6.10\n"
 
 #: ../../facetednavigation/widgets/date/widget.py:22
 msgid "1 month ago"
@@ -91,6 +93,10 @@ msgstr "Autocomplétion"
 msgid "Boolean"
 msgstr "Booléen"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr "Peut sélectionner plusieurs éléments"
+
 #. Default: ""
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
@@ -154,7 +160,7 @@ msgid "Control the range of yearsdisplayed in the year drop-down: either relativ
 msgstr "Contrôle l'interval affiché dans la liste des années: soit relatif à l'année en cours (-nn:+nn), soit relatif à l'année sélectionnée (c-nn:c+nn), soit absolu (nnnn:nnnn) ou alors une combinaison de ces formats (nnnn:-nn)."
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Compter les résultats"
 
@@ -298,7 +304,7 @@ msgid "Disable smart facets hiding"
 msgstr "Désactiver le masquage intelligent des facettes"
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Afficher le nombre de résultats de chaque valeur"
 
@@ -311,6 +317,14 @@ msgstr "Section de la widget"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Afficher le widget dans la section."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -368,15 +382,40 @@ msgstr "Valeur de l'ETAG"
 msgid "Export"
 msgstr "Exporter"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Critères"
 
 #. Default: ""
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Paramètres généraux de la navigation à facettes"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -398,6 +437,10 @@ msgstr "Recherche à facettes activée"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Paramètres"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -454,7 +497,7 @@ msgid "Hide filters"
 msgstr "Masquer les filtres"
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Masquer les éléments sans résultat"
 
@@ -739,7 +782,7 @@ msgstr "Dossier racine"
 msgid "Save"
 msgstr "Sauver"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Rechercher"
@@ -768,6 +811,10 @@ msgstr "Section"
 msgid "Select"
 msgstr "Liste de sélection"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr "Sélectionner une valeur"
+
 #. Default: ""
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
@@ -789,7 +836,7 @@ msgstr "Le masquage intelligent des facettes a été désactivé"
 msgid "Smart facets hiding is now enabled"
 msgstr "Le masquage intelligent des facettes a été activé"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr "Trier suivant le décompte"
 
@@ -844,7 +891,7 @@ msgstr "Expression Tales"
 msgid "Text field"
 msgstr "Champ texte"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr "Champ de texte avec autocomplétion"
 
@@ -853,7 +900,7 @@ msgstr "Champ de texte avec autocomplétion"
 msgid "Theme to be used with this widget"
 msgstr "Thème à utiliser avec ce widget"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Cette option ne fonctionne que si le dénombrement des résultats est activé"
 
@@ -901,7 +948,7 @@ msgstr "Interval de dates du calendrier"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Décochez cette case si vous ne voulez pas que la fonctionnalité afficher/masquer soit activée sur ce widget"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr "Utilise le compteur de résultats pour le tri"
 
@@ -954,7 +1001,7 @@ msgstr "Hier"
 msgid "all"
 msgstr "tous"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "dans tous les éléments"
@@ -963,7 +1010,7 @@ msgstr "dans tous les éléments"
 msgid "any"
 msgstr "au moins un"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "dans les résultats courants"
@@ -976,7 +1023,6 @@ msgstr "correspondance"
 msgid "match any/all filters bellow"
 msgstr "correspond à un / tous les filtres ci-dessous"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/fr/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/fr/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Type de contenu"
 
 msgid "Sort on"
 msgstr "Tri"
-

--- a/eea/facetednavigation/locales/hr/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/hr/LC_MESSAGES/eea.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: 2012-04-26 17:32+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -91,6 +91,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -145,7 +149,7 @@ msgstr ""
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr ""
 
@@ -276,7 +280,7 @@ msgstr ""
 msgid "Disable smart facets hiding"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr ""
 
@@ -286,6 +290,14 @@ msgstr ""
 
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
 msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
@@ -341,13 +353,38 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr ""
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
+msgstr ""
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
 msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
@@ -368,6 +405,10 @@ msgstr ""
 
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
 msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
@@ -420,7 +461,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr ""
 
@@ -684,7 +725,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr ""
@@ -711,6 +752,10 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr ""
@@ -731,7 +776,7 @@ msgstr ""
 msgid "Smart facets hiding is now enabled"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -782,7 +827,7 @@ msgstr ""
 msgid "Text field"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -790,7 +835,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr ""
 
@@ -834,7 +879,7 @@ msgstr ""
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -882,7 +927,7 @@ msgstr ""
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr ""
@@ -891,7 +936,7 @@ msgstr ""
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr ""
@@ -904,7 +949,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/hr/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/hr/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr ""
 
 msgid "Sort on"
 msgstr ""
-

--- a/eea/facetednavigation/locales/hu/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/hu/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Tartalom lista"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Irányítsd a tartományban yearsdisplayed az év legördülő: vagy képest a mai év (-nn: + nn) képest az aktuális év eredménye (c-nn: c + nn), az abszolút (nnnn: nnnn), vagy ezek kombinációi Ezen formátumok (nnnn:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Számlálás eredményeit"
 
@@ -273,7 +277,7 @@ msgstr "Tiltás jobb portletek"
 msgid "Disable smart facets hiding"
 msgstr "Letiltása okos arcát bujkál"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Kijelző eredmények száma közel minden lehetőség"
 
@@ -284,6 +288,14 @@ msgstr "Kijelző widget rész"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Kijelző widgetet részben."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "ETAG érték"
 msgid "Export"
 msgstr "Exportálás"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Sokoldalú feltételek"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Sokoldalú globális beállítások"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Sokoldalú keresési engedélyezve"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Sokoldalú beállításokat"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Szűrők elrejtése"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Hide tételek nulla eredmény"
 
@@ -681,7 +722,7 @@ msgstr "Gyökérmappa"
 msgid "Save"
 msgstr "Mentés"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Keresés"
@@ -708,6 +749,10 @@ msgstr "Section"
 msgid "Select"
 msgstr "Válaszon"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Minden elem kijelölése"
@@ -728,7 +773,7 @@ msgstr "Okos arcát bujkál most ki van kapcsolva"
 msgid "Smart facets hiding is now enabled"
 msgstr "Okos arcát bujkál most engedélyezve van"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Tal Expression"
 msgid "Text field"
 msgstr "Szövegmező"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Theme kell használni ezt a widgetet"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Ez az opció csak akkor működik, ha a 'számlálás eredményeit' engedélyezve van"
 
@@ -831,7 +876,7 @@ msgstr "UI naptári évig terjedhet"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Törölje ezt a rovatot, ha nem akarjuk elrejteni / show kritériumok szolgáltatás bekapcsolt, ez a widget"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "tegnap"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "Az összes tétel"
@@ -888,7 +933,7 @@ msgstr "Az összes tétel"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "A jelenlegi eredmények"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/hu/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/hu/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Szemafor"
 
 msgid "Sort on"
 msgstr "Rendezés on"
-

--- a/eea/facetednavigation/locales/is/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/is/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Efni skráningu"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Stjórna fjölda yearsdisplayed árið falla niður: annaðhvort miðað við árið í dag (-nn: + nn) og miðað við valinn árið c-nn: c + nn), alger (NNNN: NNNN), eða samsetningar þessi snið (NNNN:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Fjöldi niðurstöður"
 
@@ -273,7 +277,7 @@ msgstr "Slökkva á rétt portlets"
 msgid "Disable smart facets hiding"
 msgstr "Slökkva á sviði hliðar fela"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Sýna fjölda niðurstaðna nálægt hvern valkost"
 
@@ -284,6 +288,14 @@ msgstr "Sýna Tónlist í kafla"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Sýna ferð í kafla."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "Etag gildi"
 msgid "Export"
 msgstr "Flytja út"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Faceted viðmið"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Faceted Alþjóðlegar stillingar"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Faceted leita virkt"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Faceted stillingar"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Fela síur"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Fela atriði með núll árangri"
 
@@ -681,7 +722,7 @@ msgstr "Rót mappa"
 msgid "Save"
 msgstr "Vista"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Leita"
@@ -708,6 +749,10 @@ msgstr "Kafli"
 msgid "Select"
 msgstr "Velja"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Veldu öll atriði"
@@ -728,7 +773,7 @@ msgstr "Smart hliðar fela er nú óvirk"
 msgid "Smart facets hiding is now enabled"
 msgstr "Smart hliðar fela er nú virkt"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Tal Tjáning"
 msgid "Text field"
 msgstr "Texti sviði"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Þema að nota með þessum hlut"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Þessi valkostur virkar aðeins ef 'af telja niðurstöður' er virkt"
 
@@ -831,7 +876,7 @@ msgstr "HÍ almanaksár allt"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Taktu hakið úr þessum reit ef þú vilt ekki að fela/sýna viðmiðanir eru virkt á þessum hlut"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "Gær"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "öll atriði"
@@ -888,7 +933,7 @@ msgstr "öll atriði"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "í núverandi niðurstöður"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/is/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/is/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Portal tegund"
 
 msgid "Sort on"
 msgstr "Raða á"
-

--- a/eea/facetednavigation/locales/it/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/it/LC_MESSAGES/eea.po
@@ -3,7 +3,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eea.facetednavigation\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: 2012-03-06 21:50+0100\n"
 "Last-Translator: Giacomo Spettoli <giacomo.spettoli@gmail.com>\n"
 "Language-Team: Plone i18n <plone-i18n@lists.sourceforge.net>\n"
@@ -91,6 +91,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #. Default: ""
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
@@ -153,7 +157,7 @@ msgid "Control the range of yearsdisplayed in the year drop-down: either relativ
 msgstr "Controllare l'intervallo di yearsdisplayed nell'anno discesa: o relativo all'anno oggi (-nn: + nn), relativo all'anno selezionato (c-nn: c + nn), assoluto (nnnn: nnnn), o combinazioni di questi formati (nnnn:-nn)."
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Conteggio dei risultati"
 
@@ -295,7 +299,7 @@ msgid "Disable smart facets hiding"
 msgstr "Disabilitare sfaccettature intelligenti nascondere"
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Mostra il numero di risultati vicino ad ogni opzione"
 
@@ -308,6 +312,14 @@ msgstr "Mostra il widget nella sezione"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Mostra il widget nella sezione"
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -364,15 +376,40 @@ msgstr "Valore Etag"
 msgid "Export"
 msgstr "Esporta"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Criteri delle faccette"
 
 #. Default: ""
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Impostazioni globali delle faccette"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -394,6 +431,10 @@ msgstr "Ricerca sfaccettato abilitato"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Impostazioni delle faccette"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -450,7 +491,7 @@ msgid "Hide filters"
 msgstr "Nascondi i filtri"
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Nascondi gli elementi con zero risultati"
 
@@ -735,7 +776,7 @@ msgstr "Cartella radice"
 msgid "Save"
 msgstr "Salva"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Cerca"
@@ -764,6 +805,10 @@ msgstr "Sezione"
 msgid "Select"
 msgstr "Seleziona"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #. Default: ""
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
@@ -785,7 +830,7 @@ msgstr "Intelligente nasconde aspetti è ora disattivato"
 msgid "Smart facets hiding is now enabled"
 msgstr "Intelligente nasconde aspetti è ora abilitata"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -840,7 +885,7 @@ msgstr "Espessione Tal"
 msgid "Text field"
 msgstr "Campo di testo"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -849,7 +894,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Tema da utilizzare per questo widget"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Questa opzione funziona solo se \"conteggio dei risultati\" è abilitato"
 
@@ -896,7 +941,7 @@ msgstr "UI Anni solari vanno"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Deseleziona questo box se non vuoi la funzionalità dei criteri mostra/nascondi su questo widget"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -950,7 +995,7 @@ msgstr "Ieri"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "tutti gli elementi"
@@ -959,7 +1004,7 @@ msgstr "tutti gli elementi"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "nei risultati attuali"
@@ -972,7 +1017,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/it/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/it/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr ""
 
 msgid "Sort on"
 msgstr "Ordina per"
-

--- a/eea/facetednavigation/locales/kl/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/kl/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr ""
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr ""
 
@@ -273,7 +277,7 @@ msgstr ""
 msgid "Disable smart facets hiding"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr ""
 
@@ -283,6 +287,14 @@ msgstr ""
 
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
 msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
@@ -338,13 +350,38 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr ""
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
+msgstr ""
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
 msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
@@ -365,6 +402,10 @@ msgstr ""
 
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
 msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr ""
 
@@ -681,7 +722,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr ""
@@ -708,6 +749,10 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr ""
@@ -728,7 +773,7 @@ msgstr ""
 msgid "Smart facets hiding is now enabled"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr ""
 msgid "Text field"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr ""
 
@@ -831,7 +876,7 @@ msgstr ""
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr ""
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr ""
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr ""
@@ -888,7 +933,7 @@ msgstr ""
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr ""
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/kl/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/kl/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr ""
 
 msgid "Sort on"
 msgstr ""
-

--- a/eea/facetednavigation/locales/lt/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/lt/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Turinio sąrašas"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Valdymo diapazoną yearsdisplayed į metus išskleidžiamajame: arba santykinį šiandienos metų [-n: + NN), palyginti su šiuo metu pasirinktos metų straipsnio c-n: c + NN), absoliučią (nnnn: nnnn), arba jų derinius šių formatų (nnnn:-n)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Balsavimo rezultatų"
 
@@ -273,7 +277,7 @@ msgstr "Išjungti teisingus portlety"
 msgid "Disable smart facets hiding"
 msgstr "Išjungti protingų aspektų slepiasi"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Rodyti šalia kiekvieno varianto rezultatų skaičius"
 
@@ -284,6 +288,14 @@ msgstr "Rodyti valdikliui į skyrių"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Rodyti Skyriaus frazes."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "ETAG vertę"
 msgid "Export"
 msgstr "Eksportas"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Briaunotas kriterijai"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Briaunotas pasaulio parametrus"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Briaunotas paieška įjungta"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Briaunotas nustatymai"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Slėpti filtrus"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Slėpti elementus su nuline rezultatus"
 
@@ -681,7 +722,7 @@ msgstr "Šakninis aplankas"
 msgid "Save"
 msgstr "&Išsaugoti"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Ieškoti"
@@ -708,6 +749,10 @@ msgstr "Skyrius"
 msgid "Select"
 msgstr "Pasirinkti"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Atrinkti visus elementus"
@@ -728,7 +773,7 @@ msgstr "Smart aspektų slepiasi dabar yra išjungtas"
 msgid "Smart facets hiding is now enabled"
 msgstr "Smart aspektų slepiasi dabar įjungtas"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Sausio išraiška"
 msgid "Text field"
 msgstr "Teksto laukas"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Tema turi būti naudojamas su šio valdikliui"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Ši galimybė veikia tik tada, jei įjungtas \"balsų skaičiavimo rezultatų\""
 
@@ -831,7 +876,7 @@ msgstr "UI Kalendorius metų svyruoja"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Nuimkite šį langelį, jei nenorite slėpti / rodyti kriterijai funkcija įjungta šį valdikliui"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "Vakar"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "visi elementai"
@@ -888,7 +933,7 @@ msgstr "visi elementai"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "dabartiniais rezultatais"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/lt/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/lt/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Portalas tipas"
 
 msgid "Sort on"
 msgstr "Rūšiuoti pagal"
-

--- a/eea/facetednavigation/locales/lv/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/lv/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Satura sarakstā"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Kontrolētu klāstu yearsdisplayed gadā nolaižamajā: vai nu attiecībā pret šodienas gadu (-nn: + nn), kas atkarīga no pašlaik atlasītā gadā punkta c-nn: c + nn), absolūti (nnnn: nnnn), vai abus kopā no šiem formātiem (nnnn:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Skaita rezultātus"
 
@@ -273,7 +277,7 @@ msgstr "Atslēgt tiesības portlets"
 msgid "Disable smart facets hiding"
 msgstr "Atspējot smart šķautnes slēpjas"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Parādītu rezultātu skaits pie katras iespējas"
 
@@ -284,6 +288,14 @@ msgstr "Parādīt widget sadaļā"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Parādīt widget sadaļā."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "ETAG vērtību"
 msgid "Export"
 msgstr "Eksportēt"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Slīpētas kritērijus"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Slīpētas globālie uzstādījumi"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Slīpētas meklēšana ļāva"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Slīpētas uzstādījumi"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Paslēpt filtrus"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Paslēpt preces ar nulles rezultātu"
 
@@ -681,7 +722,7 @@ msgstr "Saknes mape"
 msgid "Save"
 msgstr "Saglabāt"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Meklēt"
@@ -708,6 +749,10 @@ msgstr "Daļa"
 msgid "Select"
 msgstr "Atlasītais"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Atlasīt visus vienumus"
@@ -728,7 +773,7 @@ msgstr "Smart šķautnes slēpjas tagad invalīds"
 msgid "Smart facets hiding is now enabled"
 msgstr "Smart šķautnes slēpjas ir iespējota"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Tal izteikšana"
 msgid "Text field"
 msgstr "Teksta lauks"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Tēma, kas jāizmanto ar šo widget"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Šī opcija darbojas tikai, ja 'skaits rezultāti' ir iespējota"
 
@@ -831,7 +876,7 @@ msgstr "UI Kalendārs gadus svārstās"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Noņemiet atzīmi šajā lodziņā, ja nevēlaties slēpt / rādīt kritēriji iezīme Javascript šo widget"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "Vakar"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "visas preces"
@@ -888,7 +933,7 @@ msgstr "visas preces"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "pašreizējās rezultātiem"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/lv/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/lv/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Portāls tips"
 
 msgid "Sort on"
 msgstr "Kārtot pēc"
-

--- a/eea/facetednavigation/locales/mt/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/mt/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Elenkar Kontenut"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Kontroll tal-firxa ta 'yearsdisplayed fis-sena drop-down: jew relattiv għal sena tal-lum (-nn: + nn), relattiva għas-sena attwalment magħżula (c-nn: c + nn), assoluta (nnnn: nnnn), jew kombinazzjonijiet ta 'dawn il-formati (nnnn:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Count riżultati"
 
@@ -273,7 +277,7 @@ msgstr "Itfi portlets dritt"
 msgid "Disable smart facets hiding"
 msgstr "Itfi aspetti intelliġenti ħabi"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Uri numru ta 'riżultati qrib kull għażla"
 
@@ -284,6 +288,14 @@ msgstr "Uri widget fis-sezzjoni"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Uri widget fis-sezzjoni."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "ETAG valur"
 msgid "Export"
 msgstr "Esportazzjoni"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Kriterji aspetti"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Settings globali aspetti"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Tfittxija aspetti ppermettiet"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Settings aspetti"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Aħbi filtri"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Hide oġġetti b'riżultati żero"
 
@@ -681,7 +722,7 @@ msgstr "Folder ta 'għerq"
 msgid "Save"
 msgstr "Ħlief"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Fittex"
@@ -708,6 +749,10 @@ msgstr "Taqsima"
 msgid "Select"
 msgstr "Agħżel"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Agħżel l-oġġetti kollha"
@@ -728,7 +773,7 @@ msgstr "Smart aspetti ħabi huwa issa diżattivat"
 msgid "Smart facets hiding is now enabled"
 msgstr "Smart aspetti ħabi issa hija ppermettiet"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Tal Espressjoni"
 msgid "Text field"
 msgstr "Qasam tat-test"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Tema li għandhom jintużaw ma 'dan widget"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Din l-għażla jaħdem biss jekk 'Riżultat għadd' hija ppermettiet"
 
@@ -831,7 +876,7 @@ msgstr "UI snin Kalendarju jvarjaw"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Uncheck din il-kaxxa jekk inti ma tridx jinħbew / Kriterji juru karatteristika mixgħula fuq dan widget"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "Ilbieraħ"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "l-oġġetti kollha"
@@ -888,7 +933,7 @@ msgstr "l-oġġetti kollha"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "fir-riżultati attwali"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/mt/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/mt/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Portal tip"
 
 msgid "Sort on"
 msgstr "Sort fuq"
-

--- a/eea/facetednavigation/locales/nl/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/nl/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Inhoudsopgave"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Controle het bereik van yearsdisplayed in het jaar drop-down: ofwel ten opzichte van de jaren de huidige (-nn: + nn), ten opzichte van de momenteel geselecteerde jaar (c-nn: c + nn), absolute (nnnn: nnnn), of combinaties van deze formaten (nnnn:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Count resultaten"
 
@@ -273,7 +277,7 @@ msgstr "Schakel rechts portlets"
 msgid "Disable smart facets hiding"
 msgstr "Schakel slimme facetten te verbergen"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Beeldscherm, aantal resultaten in de buurt van elke optie"
 
@@ -284,6 +288,14 @@ msgstr "Weergave widget in paragraaf"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Weergave widget in paragraaf."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "ETAG waarde"
 msgid "Export"
 msgstr "Exporteren"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Facet criteria"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Facet globale instellingen"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Facet zoeken ingeschakeld"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Facet instellingen"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Verberg filters"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Verberg artikelen met nul resultaten"
 
@@ -681,7 +722,7 @@ msgstr "Root map"
 msgid "Save"
 msgstr "Opslaan"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Zoeken"
@@ -708,6 +749,10 @@ msgstr "Afdeling"
 msgid "Select"
 msgstr "Select"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Selecteer alle items"
@@ -728,7 +773,7 @@ msgstr "Smart facetten schuilplaats is nu uitgeschakeld"
 msgid "Smart facets hiding is now enabled"
 msgstr "Smart facetten schuilplaats is nu ingeschakeld"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Tal Expression"
 msgid "Text field"
 msgstr "Tekstveld"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Thema voor gebruik met deze widget"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Deze optie werkt alleen als 'count resultaten' is ingeschakeld"
 
@@ -831,7 +876,7 @@ msgstr "UI Kalenderjaren variëren"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Deselecteer dit vakje aan als u niet wilt dat hide/show criteria hebben ingeschakeld op deze widget"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "Gisteren"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "Alle objecten"
@@ -888,7 +933,7 @@ msgstr "Alle objecten"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "in de huidige resultaten"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/nl/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/nl/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Portal soort"
 
 msgid "Sort on"
 msgstr "Sorteer op"
-

--- a/eea/facetednavigation/locales/no/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/no/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Innhold notering"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Styr utvalg av yearsdisplayed i år drop-down: enten i forhold til dagens år (-nn: + nn), i forhold til den valgte året (c-nn: c + nn), absolutt (nnnn: nnnn), eller kombinasjoner av disse formatene (nnnn:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Tell resultater"
 
@@ -273,7 +277,7 @@ msgstr "Deaktiver riktige portleter"
 msgid "Disable smart facets hiding"
 msgstr "Deaktiver smarte fasetter skjule"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Vis antall resultater nær hvert alternativ"
 
@@ -284,6 +288,14 @@ msgstr "Vis widget i seksjon"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Vis widget i seksjonen."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "ETAG verdi"
 msgid "Export"
 msgstr "Eksporter"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Fasettert kriterier"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Fasettert globale innstillinger"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Fasettert søk aktivert"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Fasettert innstillinger"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Skjul filtre"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Skjule elementer med null resultater"
 
@@ -681,7 +722,7 @@ msgstr "Rotmappe"
 msgid "Save"
 msgstr "Lagre"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Søk"
@@ -708,6 +749,10 @@ msgstr "Seksjo"
 msgid "Select"
 msgstr "Velg"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Velg alle elementer"
@@ -728,7 +773,7 @@ msgstr "Smart fasetter skjulested er nå deaktivert"
 msgid "Smart facets hiding is now enabled"
 msgstr "Smart fasetter skjulested er nå aktivert"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Tal Expression"
 msgid "Text field"
 msgstr "Tekstfelt"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Tema som skal brukes med denne widgeten"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Dette alternativet fungerer bare hvis 'count resultater' er aktivert"
 
@@ -831,7 +876,7 @@ msgstr "UI Kalender år spenner"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Fjern merkingen av denne boksen hvis du ikke vil vise / skjule kriterier har aktivert på denne widgeten"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "I går"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "alle elementer"
@@ -888,7 +933,7 @@ msgstr "alle elementer"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "i dagens resultater"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/no/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/no/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Portal typen"
 
 msgid "Sort on"
 msgstr "Sorter på"
-

--- a/eea/facetednavigation/locales/pl/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/pl/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eea.facetednavigation\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: 2011-05-23 13:30+0100\n"
 "Last-Translator: Jens W. Klein <jens@bluedynamics.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #. Default: ""
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
@@ -151,7 +155,7 @@ msgid "Control the range of yearsdisplayed in the year drop-down: either relativ
 msgstr "Kontrolować zakres yearsdisplayed w roku rozwijanej: albo w stosunku do dzisiejszego roku (-nn: + nn), w stosunku do aktualnie wybranego roku (c-nn: c + nn), absolutną (nnnn: nnnn), lub kombinacji z tych formatów (nnnn:-nn)."
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Zliczanie rekordów"
 
@@ -294,7 +298,7 @@ msgid "Disable smart facets hiding"
 msgstr "Wyłącz inteligentne aspekty ukrywanie"
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Wyświetlanie liczby wyników w pobliżu każdej z opcji"
 
@@ -307,6 +311,14 @@ msgstr "Ostatnia widget w dziale"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Ostatnia widżet w sekcji."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -363,15 +375,40 @@ msgstr "ETAG wartość"
 msgid "Export"
 msgstr "Eksport"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Faceted kryteria"
 
 #. Default: ""
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Faceted ustawienia globalne"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -393,6 +430,10 @@ msgstr "Faceted szukaj włączony"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Faceted ustawienia"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -449,7 +490,7 @@ msgid "Hide filters"
 msgstr "Ukryj filtry"
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Ukrywanie elementów z zerową wyników"
 
@@ -734,7 +775,7 @@ msgstr "Folder główny"
 msgid "Save"
 msgstr "Save (zapisz)"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Search"
@@ -763,6 +804,10 @@ msgstr "Rozdział"
 msgid "Select"
 msgstr "Wybierz"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #. Default: ""
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
@@ -784,7 +829,7 @@ msgstr "Inteligentne ukrywanie aspektów jest teraz wyłączony"
 msgid "Smart facets hiding is now enabled"
 msgstr "Inteligentne ukrywanie aspektów jest teraz włączony"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -839,7 +884,7 @@ msgstr "Tal Expression"
 msgid "Text field"
 msgstr "Pole tekstowe"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -848,7 +893,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Motyw do użytku z tym widgetem"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Opcja ta działa tylko wtedy, gdy 'wyniki liczyć' jest włączona"
 
@@ -896,7 +941,7 @@ msgstr "UI lata kalendarzowe wahać"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Usuń zaznaczenie tego pola, jeśli nie chcesz, ukryj / kryteria pokaż wyposażone włączona widgetu"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -950,7 +995,7 @@ msgstr "Yesterday"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "Wszystkie zagadnienia"
@@ -959,7 +1004,7 @@ msgstr "Wszystkie zagadnienia"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "Dalsze wyszukiwanie "
@@ -972,7 +1017,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/pl/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/pl/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Portal typ"
 
 msgid "Sort on"
 msgstr "Sortuj w sprawie"
-

--- a/eea/facetednavigation/locales/pt/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/pt/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Listagem de conteúdo"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Controle o intervalo de yearsdisplayed no ano drop-down: ou em relação ao ano de hoje (-nn: + nn), em relação ao ano atualmente selecionado (c-nn: c + nn), absoluto (nnnn: nnnn), ou combinações destes formatos (nnnn:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Conte com resultados"
 
@@ -273,7 +277,7 @@ msgstr "Desativar portlets direito"
 msgid "Disable smart facets hiding"
 msgstr "Desativar facetas inteligentes escondendo"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Mostrar número de resultados perto de cada opção"
 
@@ -284,6 +288,14 @@ msgstr "Mostrar widget na seção"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Mostrar widget na seção."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "ETag valor"
 msgid "Export"
 msgstr "Exportar"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Critérios facetadas"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Facetadas configurações globais"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Busca facetada habilitado"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Configurações facetadas"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Ocultar filtros"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Ocultar itens com resultados zero"
 
@@ -681,7 +722,7 @@ msgstr "Pasta raiz"
 msgid "Save"
 msgstr "salvar"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Pesquisar"
@@ -708,6 +749,10 @@ msgstr "SEÇÃO"
 msgid "Select"
 msgstr "selecção"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Selecione todos os itens"
@@ -728,7 +773,7 @@ msgstr "Escondendo facetas inteligente agora está desativado"
 msgid "Smart facets hiding is now enabled"
 msgstr "Escondendo facetas inteligente agora está habilitado"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Tal expressão"
 msgid "Text field"
 msgstr "Campo de texto"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Tema para ser usado com este widget"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Esta opção só funciona se dos resultados da contagem dos estiver ativado"
 
@@ -831,7 +876,7 @@ msgstr "Anos UI Calendário variar"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Desmarque esta caixa se você não quer esconder / Critérios mostram recurso ativado neste widget"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "Ontem"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "Todos itens"
@@ -888,7 +933,7 @@ msgstr "Todos itens"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "em resultados atuais"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/pt/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/pt/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Tipo de Portal"
 
 msgid "Sort on"
 msgstr "Classificar por"
-

--- a/eea/facetednavigation/locales/pt_BR/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/pt_BR/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: 2013-05-12 19:29-0300\n"
 "Last-Translator: Gustavo Lepri <gustavolepri@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -89,6 +89,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -143,7 +147,7 @@ msgstr "Listagem de conteúdo"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Controle o intervalo da exibição dos anos no drop-down do ano: quer em relação ao ano corrente (-nn: + nn), em relação ao ano atualmente selecionado (c-nn: c + nn), absoluto (nnnn: nnnn), ou combinações destes formatos (nnnn:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Contar os resultados"
 
@@ -274,7 +278,7 @@ msgstr "Desabilitar portlets da direita"
 msgid "Disable smart facets hiding"
 msgstr "Desabilitar facetas inteligentes escondendo"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Exibir número de resultados perto de cada opção"
 
@@ -285,6 +289,14 @@ msgstr "Exibir widget na seção"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Exibir widget na seção."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -339,14 +351,39 @@ msgstr "Valor ETag"
 msgid "Export"
 msgstr "Exportar"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Critérios facetadas"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Facetadas configurações globais"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -367,6 +404,10 @@ msgstr "Busca facetada habilitada"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Configurações facetadas"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -418,7 +459,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Ocultar filtros"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Ocultar itens com resultados zero"
 
@@ -682,7 +723,7 @@ msgstr "Pasta raiz"
 msgid "Save"
 msgstr "Salvar"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Pesquisar"
@@ -709,6 +750,10 @@ msgstr "Seção"
 msgid "Select"
 msgstr "Seleção"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Selecione todos os itens"
@@ -729,7 +774,7 @@ msgstr "Esconder facetas inteligente agora está desabilitado"
 msgid "Smart facets hiding is now enabled"
 msgstr "Esconder facetas inteligente agora está habilitado"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr "Ordenar por contável"
 
@@ -780,7 +825,7 @@ msgstr "Expressão TAL"
 msgid "Text field"
 msgstr "Campo de texto"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -788,7 +833,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Tema para ser usado com este widget"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Esta opção só funciona se os resultados da contagem estiver ativado"
 
@@ -832,7 +877,7 @@ msgstr "Intervalo de anos do Calendário UI"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Desmarque esta caixa se você não quer esconder/exibir critérios de recurso habilitado neste widget"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr "Utilizar o contador para classificar resultados"
 
@@ -880,7 +925,7 @@ msgstr "Ontem"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "todos os itens"
@@ -889,7 +934,7 @@ msgstr "todos os itens"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "em resultados atuais"
@@ -902,7 +947,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/pt_BR/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/pt_BR/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Tipo de Portal"
 
 msgid "Sort on"
 msgstr "Classificar por"
-

--- a/eea/facetednavigation/locales/ro/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/ro/LC_MESSAGES/eea.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: 2011-09-08 12:00+0000\n"
 "Last-Translator: Alin Voinea <alin@eaudeweb.ro>\n"
 "Language-Team: Bogdan Ciobanu <bogdan.ciobanu@eaudeweb.ro>\n"
@@ -91,6 +91,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #. Default: ""
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
@@ -154,7 +158,7 @@ msgid "Control the range of yearsdisplayed in the year drop-down: either relativ
 msgstr ""
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Numără rezultatele"
 
@@ -297,7 +301,7 @@ msgid "Disable smart facets hiding"
 msgstr "Dezactivează ascunderea inteligentă a faţetelor"
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Afişează numărul de rezultate lângă fiecare opţiune"
 
@@ -310,6 +314,14 @@ msgstr "Afişează widget-ul în secţiunea"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Afişează widget-ul în secţiunea"
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -366,15 +378,40 @@ msgstr "Valoare ETag"
 msgid "Export"
 msgstr "Exportă"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Navigare faţetată"
 
 #. Default: ""
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Setări generale pentru navigarea faţetată"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -396,6 +433,10 @@ msgstr "Căutarea faţetată activată"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Setări navigare faţetată"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -452,7 +493,7 @@ msgid "Hide filters"
 msgstr "Ascunde filtrele"
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Ascundere elementele care nu generează nici un rezultat"
 
@@ -737,7 +778,7 @@ msgstr "Director rădăcină"
 msgid "Save"
 msgstr "Salvează"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Caută"
@@ -766,6 +807,10 @@ msgstr "Secţiune"
 msgid "Select"
 msgstr "Selectare"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #. Default: ""
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
@@ -787,7 +832,7 @@ msgstr "Ascunderea inteligentă a faţetelor a fost dezactivată"
 msgid "Smart facets hiding is now enabled"
 msgstr "Ascunderea inteligentă a faţetelor a fost activată"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr "Sortează după numărul de elementele"
 
@@ -842,7 +887,7 @@ msgstr "Expresie TAL"
 msgid "Text field"
 msgstr "Câmp text"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -851,7 +896,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Tema folosită pentru a afisa acest widget"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Această opţiune funcţionează doar împreună cu opţiunea 'Numără rezultatele'"
 
@@ -898,7 +943,7 @@ msgstr ""
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Deselectează aceasta opţiune dacă nu vrei 'ascunde/arată criteriile' activă pentru acest widget"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr "Utilizează contorul rezultat pentru sortare"
 
@@ -952,7 +997,7 @@ msgstr "Ieri"
 msgid "all"
 msgstr "toate"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "toate elementele"
@@ -961,7 +1006,7 @@ msgstr "toate elementele"
 msgid "any"
 msgstr "oricare"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "în rezultatele curente"
@@ -974,7 +1019,6 @@ msgstr "conţine"
 msgid "match any/all filters bellow"
 msgstr "filtrează elementele care conţin toate sau oricare dintre filtrele de mai jos"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/ro/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/ro/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Tip"
 
 msgid "Sort on"
 msgstr "Sortare după"
-

--- a/eea/facetednavigation/locales/ru/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/ru/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Содержимое листинга"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Контроль диапазона yearsdisplayed в год выпадающий: либо относительно текущий год (-п + п), относительно выбранного года (С-П: С + П), абсолютный (NNNN: NNNN), или их комбинации из этих форматов (NNNN:-п)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Результаты подсчета"
 
@@ -273,7 +277,7 @@ msgstr "Запретить портлетов"
 msgid "Disable smart facets hiding"
 msgstr "Отключить смарт грани скрываются"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Показать количество результатов у каждого варианта"
 
@@ -284,6 +288,14 @@ msgstr "Отображение виджетов в разделе"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Отображение виджета в секции."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "Etag значение"
 msgid "Export"
 msgstr "Экспорт"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Грановитая критериям"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Грановитая глобальные настройки"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Грановитая поиск включен"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Грановитая настройки"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Скрыть фильтр"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Скрыть элементы с нулевыми результатами"
 
@@ -681,7 +722,7 @@ msgstr "[Корневая папка]"
 msgid "Save"
 msgstr "Сохраненный"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Поиск"
@@ -708,6 +749,10 @@ msgstr "разделы :"
 msgid "Select"
 msgstr "Выборочно"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Выделение всех элементов"
@@ -728,7 +773,7 @@ msgstr "Смарт скрываться грани теперь отключен
 msgid "Smart facets hiding is now enabled"
 msgstr "Смарт скрываться грани теперь включен"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Таль Выражение"
 msgid "Text field"
 msgstr "Текстовое поле"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Темы, которые будут использоваться с этим виджетом"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Эта опция работает только если 'Количество результатов' включен"
 
@@ -831,7 +876,7 @@ msgstr "Пользовательский интерфейс календаря �
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Снимите этот флажок, если вы не хотите скрыть / показать критерии имеют включен этот виджет"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "Вчера"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "все элементы"
@@ -888,7 +933,7 @@ msgstr "все элементы"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "в текущих результатов"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/ru/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/ru/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Портал типа"
 
 msgid "Sort on"
 msgstr "Сортировать по"
-

--- a/eea/facetednavigation/locales/sk/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/sk/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Obsah stránok"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Meniť rozsah yearsdisplayed vo výbere roku: buď vzhľadom k dnešnému roku (-nn:+nn), relatívne vzhľadom k práve vybranému rok (c-nn:c+nn), absolútne (nnnn:nnnn), alebo kombinácia z týchto formátov (nnnn:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Počítať výsledky"
 
@@ -273,7 +277,7 @@ msgstr "Zakázať portlety vpravo"
 msgid "Disable smart facets hiding"
 msgstr "Zakázať inteligentné skrývanie fazetového vyhľadávania"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Zobraziť počet výsledkov v blízkosti každej voľby"
 
@@ -284,6 +288,14 @@ msgstr "Zobraziť ovládací prvok v sekcii"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Zobraziť ovládací prvok v sekcii."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "Hodnota etagu"
 msgid "Export"
 msgstr "Export"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Kritériá fazetového vyhľadávania"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Globálne nastavenia fazetového vyhľadávania"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Fazetové vyhľadávanie povolené"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Nastavenie fazetového vyhľadávania"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr "Skryť možnosť 'Všetko'"
 msgid "Hide filters"
 msgstr "Skryť filtre"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Skryť položky s prázdnym výsledkom"
 
@@ -681,7 +722,7 @@ msgstr "Koreňová zložka"
 msgid "Save"
 msgstr "Uložiť"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Hľadať"
@@ -708,6 +749,10 @@ msgstr "Časť"
 msgid "Select"
 msgstr "Vybrať"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Vybrať všetky položky"
@@ -728,7 +773,7 @@ msgstr "Inteligentné skrývanie fazetovej navigácie je teraz zakázané"
 msgid "Smart facets hiding is now enabled"
 msgstr "Inteligentné skrývanie fazetovej navigácie je teraz povolené"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr "Zoradiť podľa počítadiel"
 
@@ -779,7 +824,7 @@ msgstr "Tal výraz"
 msgid "Text field"
 msgstr "Textové pole"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Téma pre použitie s touto miniaplikáciou"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Táto možnosť funguje iba vtedy, ak je povolená možnosť 'sčítať výsledky'"
 
@@ -831,7 +876,7 @@ msgstr "Rozsah rokov UI kalendára"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Zrušte začiarknutie tohto políčka, ak nechcete mať povolené možnosti zobraziť/skryť pre túto miniaplikáciu"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "Včera"
 msgid "all"
 msgstr "všetky"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "všetky položky"
@@ -888,7 +933,7 @@ msgstr "všetky položky"
 msgid "any"
 msgstr "niektoré"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "v aktuálnych výsledkoch"
@@ -901,7 +946,6 @@ msgstr "zhoda"
 msgid "match any/all filters bellow"
 msgstr "zodpovedajú niektorému/všetkým filtrom nižšie"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/sk/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/sk/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Portálový typ"
 
 msgid "Sort on"
 msgstr "Zoradiť"
-

--- a/eea/facetednavigation/locales/sl/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/sl/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Seznamu vsebine"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Nadzor nad vrsto yearsdisplayed v letu spustnem: bodisi glede na leto današnji (-nn: + nn), ki glede na trenutno izbrano leto (C-nn: c + nn), ki absolutno (nnnn: nnnn) ali s kombinacijo od teh formatov (nnnn:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Računajo rezultate"
 
@@ -273,7 +277,7 @@ msgstr "Onemogoči prave portletov"
 msgid "Disable smart facets hiding"
 msgstr "Onemogoči pametne plati skriva"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Prikaže število rezultatov ob vsaki možnosti"
 
@@ -284,6 +288,14 @@ msgstr "Prikazovanje widget na delu"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Prikazovanje widget na odseku."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "ETAG vrednost"
 msgid "Export"
 msgstr "Izvoz"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Obrazi merila"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Obrazi globalne nastavitve"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Obrazi iskanje omogočen"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Obrazi Nastavitve"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Skrij filtri"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Skrij postavke z nič rezultatov"
 
@@ -681,7 +722,7 @@ msgstr "Root mapa"
 msgid "Save"
 msgstr "Shrani"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Išči"
@@ -708,6 +749,10 @@ msgstr "Razdelek 3"
 msgid "Select"
 msgstr "Izberi"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Izberite vse predmete"
@@ -728,7 +773,7 @@ msgstr "Smart plati skriva je zdaj onemogočen"
 msgid "Smart facets hiding is now enabled"
 msgstr "Smart plati skriva je zdaj omogočeno"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Tal Expression"
 msgid "Text field"
 msgstr "Besedilo polje"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Tema, ki se uporabljajo s to widget"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Ta možnost deluje le, če je omogočena davčna izpostava štetje results '"
 
@@ -831,7 +876,7 @@ msgstr "UI Koledar let segajo"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Počistite to polje, če ne želite Skrij / prikaži merila funkcija omogočena ta widget"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "Včeraj"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "Vsi elementi"
@@ -888,7 +933,7 @@ msgstr "Vsi elementi"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "V trenutnih rezultatih"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/sl/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/sl/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Portal vrsta"
 
 msgid "Sort on"
 msgstr "Razvrsti na"
-

--- a/eea/facetednavigation/locales/sv/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/sv/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "Innehållet notering"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Styr olika yearsdisplayed i år drop-down: antingen i förhållande till dagens året (-nn: + nn), i förhållande till den valda året (c-nn: c + nn), absolut (nnnn: nnnn), eller kombinationer dessa format (nnnn:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Räkna resultat"
 
@@ -273,7 +277,7 @@ msgstr "Inaktivera rät portletar"
 msgid "Disable smart facets hiding"
 msgstr "Inaktivera smarta fasetter dölja"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Visa antal resultat i närheten av varje alternativ"
 
@@ -284,6 +288,14 @@ msgstr "Visa widget i avsnitt"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Visa widget avsnitt."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "ETAG värde"
 msgid "Export"
 msgstr "Export"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Fasetterade kriterier"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Mångfasetterade globala inställningar"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Fasetterad sökning aktiverat"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Fasetterade inställningar"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Dölj filter"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Dölja objekt med nollresultat"
 
@@ -681,7 +722,7 @@ msgstr "Rotmapp"
 msgid "Save"
 msgstr "Spara"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Sök"
@@ -708,6 +749,10 @@ msgstr "Avsnitt"
 msgid "Select"
 msgstr "Välj"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Välja alla objekt"
@@ -728,7 +773,7 @@ msgstr "Smart aspekter nederlag är nu inaktiverad"
 msgid "Smart facets hiding is now enabled"
 msgstr "Smart aspekter nederlag är nu aktiverad"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Tal Expression"
 msgid "Text field"
 msgstr "Textfält"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Tema som ska användas med den här widgeten"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "Det här alternativet fungerar bara om 'count resultat är aktiverat"
 
@@ -831,7 +876,7 @@ msgstr "UI kalenderår allt"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Avmarkera denna ruta om du inte vill dölja / visa kriterier har aktiverat på denna widget"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "I går"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "alla objekt"
@@ -888,7 +933,7 @@ msgstr "alla objekt"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "i nuvarande resultat"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/sv/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/sv/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Portal typ"
 
 msgid "Sort on"
 msgstr "Sortera på"
-

--- a/eea/facetednavigation/locales/tr/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/tr/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
 #: ../../facetednavigation/widgets/select/widget.py:40
@@ -142,7 +146,7 @@ msgstr "İçerik listesi"
 msgid "Control the range of yearsdisplayed in the year drop-down: either relative to today's year (-nn:+nn), relative to the currently selected year (c-nn:c+nn), absolute (nnnn:nnnn), or combinations of these formats (nnnn:-nn)."
 msgstr "Seçili yıl (c-nn: c + nn) göre,: bugünün yıl (-nn + nn) için ya göre:, mutlak (nnnn: nnnn), veya birleşimleri açılan yıl yearsdisplayed aralığı kontrol Bu formatların (nnnn:-nn)."
 
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "Maçların sonuçları"
 
@@ -273,7 +277,7 @@ msgstr "Sağ portletler sakatlar"
 msgid "Disable smart facets hiding"
 msgstr "Akıllı yönleriyle gizleme sakatlar"
 
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "Her seçeneğin yakınında sonuç sayısını görüntüle"
 
@@ -284,6 +288,14 @@ msgstr "Bölümünde aracı gösterilecek"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "Bölümünde Widget görüntüler."
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -338,14 +350,39 @@ msgstr "Değeri etag"
 msgid "Export"
 msgstr "İhracat"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Yönlü kriterleri"
 
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Yönlü genel ayarlar"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -366,6 +403,10 @@ msgstr "Yönlü arama etkin"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Yönlü ayarları"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -417,7 +458,7 @@ msgstr ""
 msgid "Hide filters"
 msgstr "Filtreleri gizle"
 
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "Sıfır sonuçları ile öğeleri gizle"
 
@@ -681,7 +722,7 @@ msgstr "Kök klasörü"
 msgid "Save"
 msgstr "Kaydet"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "Ara"
@@ -708,6 +749,10 @@ msgstr "Bölüm"
 msgid "Select"
 msgstr "Seç"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
 msgstr "Tüm öğeleri seçme"
@@ -728,7 +773,7 @@ msgstr "Akıllı yönleri gizleme artık devre dışı"
 msgid "Smart facets hiding is now enabled"
 msgstr "Akıllı yönleri gizleme artık etkindir"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr ""
 
@@ -779,7 +824,7 @@ msgstr "Tal İfade"
 msgid "Text field"
 msgstr "Metin alanı"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -787,7 +832,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "Bu widget ile kullanılmak üzere Tema"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "'Sayımı sonuçları' etkinse, bu seçenek sadece çalışır"
 
@@ -831,7 +876,7 @@ msgstr "UI Takvim yaş aralığı"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "Eğer istemiyorsanız işareti kaldırın bu kutuyu gizlemek / göstermek kriterleri bu widget etkin özelliği"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr ""
 
@@ -879,7 +924,7 @@ msgstr "Dün"
 msgid "all"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "tüm öğeler"
@@ -888,7 +933,7 @@ msgstr "tüm öğeler"
 msgid "any"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "Mevcut sonuçlar"
@@ -901,7 +946,6 @@ msgstr ""
 msgid "match any/all filters bellow"
 msgstr ""
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/tr/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/tr/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "Portal tipi"
 
 msgid "Sort on"
 msgstr "Sırala"
-

--- a/eea/facetednavigation/locales/zh_TW/LC_MESSAGES/eea.po
+++ b/eea/facetednavigation/locales/zh_TW/LC_MESSAGES/eea.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: eea\n"
-"POT-Creation-Date: 2015-09-04 11:47+0000\n"
+"POT-Creation-Date: 2016-02-23 12:02+0000\n"
 "PO-Revision-Date: 2013-12-31 23:42+0800\n"
 "Last-Translator: TsungWei Hu <marr.tw@gmail.com>\n"
 "Language-Team: Plone I18N <plone-i18n@lists.sourceforge.net>\n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Boolean"
 msgstr ""
 
+#: ../../facetednavigation/widgets/autocomplete/widget.py:75
+msgid "Can select several elements"
+msgstr ""
+
 #. Default: ""
 #: ../../facetednavigation/widgets/checkbox/widget.py:70
 #: ../../facetednavigation/widgets/radio/widget.py:43
@@ -151,7 +155,7 @@ msgid "Control the range of yearsdisplayed in the year drop-down: either relativ
 msgstr "控制 yearsdisplayed 的變數範圍：可以是今年的相對值 (-nn:+nn)，某一年的相對值 (c-nn:c+nn)，絕對值 (nnnn:nnnn)，或是混合格式。"
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:343
+#: ../../facetednavigation/widgets/widget.py:344
 msgid "Count results"
 msgstr "顯示數量"
 
@@ -294,7 +298,7 @@ msgid "Disable smart facets hiding"
 msgstr "停用 smart facets hiding"
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:344
+#: ../../facetednavigation/widgets/widget.py:345
 msgid "Display number of results near each option"
 msgstr "依選項顯示數量"
 
@@ -307,6 +311,14 @@ msgstr "在區段顯示方框"
 #: ../../facetednavigation/browser/template/configure.pt:55
 msgid "Display widget in section."
 msgstr "在區段顯示方框。"
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "EEA Faceted Navigation"
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:35
+msgid "EEA Faceted Navigation Common Configuration"
+msgstr ""
 
 #: ../../facetednavigation/profiles/common/actions.xml
 msgid "Enable faceted navigation"
@@ -364,15 +376,40 @@ msgstr "Etag 值"
 msgid "Export"
 msgstr "匯出"
 
+#: ../../facetednavigation/profiles.zcml:35
+msgid "Extension profile for EEA Faceted Navigation settings that                    aren't version dependent."
+msgstr ""
+
+#: ../../facetednavigation/profiles.zcml:17
+msgid "Extension profile for EEA Faceted Navigation."
+msgstr ""
+
 #: ../../facetednavigation/profiles/bbb/actions.xml
 #: ../../facetednavigation/profiles/default/actions.xml
 msgid "Faceted criteria"
 msgstr "Faceted 條件"
 
 #. Default: ""
+#: ../../facetednavigation/settings/configure.zcml:19
 #: ../../facetednavigation/settings/menu.py:22
 msgid "Faceted global settings"
 msgstr "Faceted 導覽的設定值"
+
+#: ../../facetednavigation/views/configure.zcml:20
+msgid "Faceted items preview"
+msgstr ""
+
+#: ../../facetednavigation/views/example/configure.zcml:21
+msgid "Faceted listing view"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigable"
+msgstr ""
+
+#: ../../facetednavigation/dexterity.zcml:11
+msgid "Faceted navigation can be activated on the instances of this content type."
+msgstr ""
 
 #: ../../facetednavigation/subtypes/subtyper.py:143
 msgid "Faceted navigation disabled"
@@ -394,6 +431,10 @@ msgstr "Faceted 搜尋已啟用"
 #: ../../facetednavigation/settings/menu.py:21
 msgid "Faceted settings"
 msgstr "Faceted 導覽設定"
+
+#: ../../facetednavigation/views/example/configure.zcml:13
+msgid "Faceted summary view"
+msgstr ""
 
 #: ../../facetednavigation/widgets/interfaces.py:31
 msgid "Factory"
@@ -450,7 +491,7 @@ msgid "Hide filters"
 msgstr "隱藏條件"
 
 #. Default: ""
-#: ../../facetednavigation/widgets/widget.py:357
+#: ../../facetednavigation/widgets/widget.py:358
 msgid "Hide items with zero results"
 msgstr "隱藏數量為零的結果"
 
@@ -735,7 +776,7 @@ msgstr "根目錄"
 msgid "Save"
 msgstr "儲存"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:28
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:34
 #: ../../facetednavigation/widgets/text/widget.pt:25
 msgid "Search"
 msgstr "搜尋"
@@ -765,6 +806,10 @@ msgstr "區段"
 msgid "Select"
 msgstr "選擇方框"
 
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:1
+msgid "Select a value"
+msgstr ""
+
 #. Default: ""
 #: ../../facetednavigation/browser/template/configure.pt:112
 msgid "Select all items"
@@ -786,7 +831,7 @@ msgstr "Smart Facets Hiding 已停用"
 msgid "Smart facets hiding is now enabled"
 msgstr "Smart Facets Hiding 已啟用"
 
-#: ../../facetednavigation/widgets/widget.py:350
+#: ../../facetednavigation/widgets/widget.py:351
 msgid "Sort by countable"
 msgstr "依計數結果排序"
 
@@ -841,7 +886,7 @@ msgstr "TAL 表示式"
 msgid "Text field"
 msgstr "文字欄位"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:77
+#: ../../facetednavigation/widgets/autocomplete/widget.py:86
 msgid "Text field with suggestions"
 msgstr ""
 
@@ -850,7 +895,7 @@ msgstr ""
 msgid "Theme to be used with this widget"
 msgstr "方框要搭配的佈景主題"
 
-#: ../../facetednavigation/widgets/widget.py:358
+#: ../../facetednavigation/widgets/widget.py:359
 msgid "This option works only if 'count results' is enabled"
 msgstr "啟用「顯示數量」時，這個設定值才會生效。"
 
@@ -897,7 +942,7 @@ msgstr "日曆的年份範圍"
 msgid "Uncheck this box if you don't want hide/show criteria feature enabled on this widget"
 msgstr "不想 Hide/Show 條件功能被啟用的話，請取消勾選。"
 
-#: ../../facetednavigation/widgets/widget.py:351
+#: ../../facetednavigation/widgets/widget.py:352
 msgid "Use the results counter for sorting"
 msgstr "依計數結果來排序"
 
@@ -951,7 +996,7 @@ msgstr "昨天"
 msgid "all"
 msgstr "全部"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:38
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:44
 #: ../../facetednavigation/widgets/text/widget.pt:35
 msgid "all items"
 msgstr "所有項目"
@@ -960,7 +1005,7 @@ msgstr "所有項目"
 msgid "any"
 msgstr "任何"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.pt:47
+#: ../../facetednavigation/widgets/autocomplete/widget.pt:53
 #: ../../facetednavigation/widgets/text/widget.pt:44
 msgid "in current results"
 msgstr "在現行結果裡"
@@ -973,7 +1018,6 @@ msgstr "符合"
 msgid "match any/all filters bellow"
 msgstr "符合 Any/All 過濾條件"
 
-#: ../../facetednavigation/widgets/autocomplete/widget.py:155
+#: ../../facetednavigation/widgets/autocomplete/widget.py:169
 msgid "solr"
 msgstr ""
-

--- a/eea/facetednavigation/locales/zh_TW/LC_MESSAGES/plone.po
+++ b/eea/facetednavigation/locales/zh_TW/LC_MESSAGES/plone.po
@@ -31,4 +31,3 @@ msgstr "內容型別"
 
 msgid "Sort on"
 msgstr "排序條件"
-

--- a/eea/facetednavigation/profiles/default/metadata.xml
+++ b/eea/facetednavigation/profiles/default/metadata.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0"?>
 <metadata>
- <version>8.4</version>
+ <version>8.8</version>
  <dependencies>
   <dependency>profile-eea.jquery:28-browser</dependency>
+  <dependency>profile-eea.jquery:23-select2</dependency>
   <dependency>profile-eea.facetednavigation:universal</dependency>
  </dependencies>
 </metadata>

--- a/eea/facetednavigation/tests/autocomplete.py
+++ b/eea/facetednavigation/tests/autocomplete.py
@@ -1,0 +1,30 @@
+import json
+from Products.Five import BrowserView
+from zope.interface import implements
+
+from eea.faceted.vocabularies.autocomplete import IAutocompleteSuggest
+
+vocab = [
+    ('Document', u"Document"),
+    ('Event', u"Event"),
+    ('Folder', u"Folder"),
+]
+
+class TypesSuggest(BrowserView):
+    """ Types Autocomplete view """
+    implements(IAutocompleteSuggest)
+
+    label = u"Types"
+
+    def __call__(self):
+        result = []
+        query = self.request.get('term')
+        if not query:
+            return json.dumps(result)
+
+        self.request.response.setHeader("Content-type", "application/json")
+        for term in vocab:
+            if term[1].lower().startswith(query.lower()):
+                result.append({'id': term[0], 'text': term[1]})
+
+        return json.dumps(result)

--- a/eea/facetednavigation/tests/autocomplete.zcml
+++ b/eea/facetednavigation/tests/autocomplete.zcml
@@ -1,0 +1,14 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser">
+
+<!-- vocabulary for the types autocomplete faceted widget -->
+  <browser:view
+    for="*"
+    provides="eea.faceted.vocabularies.autocomplete.IAutocompleteSuggest"
+    name="types-autocomplete-suggest"
+    class=".autocomplete.TypesSuggest"
+    permission="zope2.View"
+  />
+
+</configure>

--- a/eea/facetednavigation/tests/base.py
+++ b/eea/facetednavigation/tests/base.py
@@ -31,6 +31,7 @@ def setup_eea_facetednavigation():
     zcml.load_config('overrides.zcml', facetednavigation)
     zcml.load_config('configure.zcml', facetednavigation.subtypes)
     zcml.load_config('configure.zcml', facetednavigation)
+    zcml.load_config('autocomplete.zcml', facetednavigation.tests)
     fiveconfigure.debug_mode = False
 
 setup_eea_facetednavigation()

--- a/eea/facetednavigation/tests/test_widgets.py
+++ b/eea/facetednavigation/tests/test_widgets.py
@@ -64,3 +64,23 @@ class WidgetTestCase(FacetedTestCase):
         self.request.form['SearchableText'] = 'serious fun'
         widget = Widget(self.portal, self.request, data=data)
         self.assertEqual(widget.default, 'serious fun')
+
+
+
+class AutocompleteWidgetTestCase(FacetedTestCase):
+    """ Test
+    """
+
+    def afterSetUp(self):
+        """ Setup
+        """
+        self.request = self.app.REQUEST
+
+    def test_comma_separated_values(self):
+        """ Comma separated values are transformed to a list
+        """
+        from eea.facetednavigation.widgets.autocomplete.widget import Widget
+        data = {}
+        value = 'Folder,Document'
+        widget = Widget(self.portal, self.request, data=data)
+        self.assertEqual(widget.normalize(value), ['Folder', 'Document'])

--- a/eea/facetednavigation/upgrades/configure.zcml
+++ b/eea/facetednavigation/upgrades/configure.zcml
@@ -5,6 +5,17 @@
   i18n_domain="eea">
 
   <genericsetup:upgradeSteps
+    source="8.4"
+    destination="8.8"
+    profile="eea.facetednavigation:default">
+
+  <genericsetup:upgradeStep
+      title="Register select2 in portal_javascripts, needed for the autocomplete widget"
+      handler="eea.facetednavigation.upgrades.evolve88.install_select2"
+      />
+  </genericsetup:upgradeSteps>
+
+  <genericsetup:upgradeSteps
     source="7.5"
     destination="8.4"
     profile="eea.facetednavigation:default">

--- a/eea/facetednavigation/upgrades/evolve88.py
+++ b/eea/facetednavigation/upgrades/evolve88.py
@@ -1,0 +1,18 @@
+""" Upgrade to version 8.8
+"""
+import logging
+from Products.CMFCore.utils import getToolByName
+
+logger = logging.getLogger("eea.facetednavigation")
+
+
+def install_select2(context):
+    """
+    In version 8.8, the autocomplete widget uses select2 instead of
+    jquery.autocomplete.
+    """
+
+    context.runAllImportStepsFromProfile('profile-eea.jquery:23-select2')
+    js_tool = getToolByName(context, 'portal_javascripts')
+    js_tool.cookResources()
+    logger.info('Installed select2 dependency')

--- a/eea/facetednavigation/widgets/autocomplete/view.css
+++ b/eea/facetednavigation/widgets/autocomplete/view.css
@@ -6,3 +6,9 @@
   height:1px;
   overflow:hidden;
 }
+#content ul.select2-choices {
+    margin-left: 0;
+}
+.select2-container-multi .select2-choices .select2-search-field input {
+    min-width: 100px;
+}

--- a/eea/facetednavigation/widgets/autocomplete/view.js
+++ b/eea/facetednavigation/widgets/autocomplete/view.js
@@ -166,12 +166,15 @@ Faceted.initializeAutocompleteWidget = function(evt){
   jQuery('div.faceted-autocomplete-widget').each(function(){
     var wid = jQuery(this).attr('id');
     var autocomplete_view = jQuery(this).attr('data-autocomplete-view');
+    var multiple = (jQuery(this).attr('data-multiple') === 'true');
+    var placeholder = jQuery(this).attr('data-placeholder');
     wid = wid.split('_')[0];
     Faceted.Widgets[wid] = new Faceted.AutocompleteWidget(wid);
 
     jQuery("#" + wid).select2({
-      placeholder: "Select an option",
-      multiple: true,
+      placeholder: placeholder,
+      multiple: multiple,
+      allowClear: true,
       ajax: {
         url: autocomplete_view,
         delay: 250,
@@ -192,7 +195,7 @@ Faceted.initializeAutocompleteWidget = function(evt){
     });
   });
 };
-  
+
 jQuery(document).ready(function(){
   jQuery(Faceted.Events).bind(
     Faceted.Events.INITIALIZE,

--- a/eea/facetednavigation/widgets/autocomplete/view.js
+++ b/eea/facetednavigation/widgets/autocomplete/view.js
@@ -175,7 +175,7 @@ Faceted.initializeAutocompleteWidget = function(evt){
       placeholder: placeholder,
       multiple: multiple,
       allowClear: true,
-      minimumInputLength: 1,
+      minimumInputLength: 2,
       ajax: {
         url: autocomplete_view,
         delay: 250,

--- a/eea/facetednavigation/widgets/autocomplete/view.js
+++ b/eea/facetednavigation/widgets/autocomplete/view.js
@@ -39,7 +39,7 @@ Faceted.AutocompleteWidget.prototype = {
   },
 
   do_query: function(element){
-    var input = jQuery('#value_' + this.wid);
+    var input = jQuery('#' + this.wid);
     var value = input.val();
     value = value ? [value] : [];
 
@@ -168,19 +168,31 @@ Faceted.initializeAutocompleteWidget = function(evt){
     var autocomplete_view = jQuery(this).attr('data-autocomplete-view');
     wid = wid.split('_')[0];
     Faceted.Widgets[wid] = new Faceted.AutocompleteWidget(wid);
-      jQuery("#" + wid).autocomplete({
-        source:  autocomplete_view,
-        minLength: 2,
-        select: function (event, ui) {
-            event.preventDefault();
-            jQuery('#value_' + this.id).val(ui.item.value);
-            jQuery(this).val(ui.item.label);
-        }
+
+    jQuery("#" + wid).select2({
+      placeholder: "Select an option",
+      multiple: true,
+      ajax: {
+        url: autocomplete_view,
+        delay: 250,
+        dataType: 'json',
+        data: function (term, page) {
+            return {
+                term: term,
+                add_terms: true
+            };
+        },
+        results: function (data, page) {
+            return {
+                results: data
+            };
+        },
+        cache: false,
+      },
     });
   });
-
 };
-
+  
 jQuery(document).ready(function(){
   jQuery(Faceted.Events).bind(
     Faceted.Events.INITIALIZE,

--- a/eea/facetednavigation/widgets/autocomplete/view.js
+++ b/eea/facetednavigation/widgets/autocomplete/view.js
@@ -175,6 +175,7 @@ Faceted.initializeAutocompleteWidget = function(evt){
       placeholder: placeholder,
       multiple: multiple,
       allowClear: true,
+      minimumInputLength: 1,
       ajax: {
         url: autocomplete_view,
         delay: 250,

--- a/eea/facetednavigation/widgets/autocomplete/widget.pt
+++ b/eea/facetednavigation/widgets/autocomplete/widget.pt
@@ -7,7 +7,13 @@
   default_label python:view.default and view.default.get('label') or '';
   css string:faceted-widget ${view/css_class};
   css python:hidden and css + ' faceted-widget-hidden' or css;"
-  tal:attributes="id string:${wid}_widget; class css; data-autocomplete-view view/autocomplete_view">
+  data-placeholder="Select a value"
+  i18n:attributes="data-placeholder"
+  tal:attributes="
+    id string:${wid}_widget; class css;
+    data-autocomplete-view view/autocomplete_view;
+    data-multiple python:str(getattr(view.data, 'multivalued', True)).lower();
+">
 
 <fieldset class="widget-fieldset"
   tal:define="title python:view.data.get('title', '')">

--- a/eea/facetednavigation/widgets/autocomplete/widget.py
+++ b/eea/facetednavigation/widgets/autocomplete/widget.py
@@ -66,6 +66,15 @@ EditSchema = Schema((
             i18n_domain="eea"
         )
     ),
+
+    BooleanField(
+        'multivalued',
+        schemata="default",
+        default=True,
+        widget=BooleanWidget(
+            label=_(u'Can select several elements'),
+        )
+    ),
 ))
 
 

--- a/eea/facetednavigation/widgets/autocomplete/widget.py
+++ b/eea/facetednavigation/widgets/autocomplete/widget.py
@@ -114,6 +114,9 @@ class Widget(AbstractWidget):
     def normalize(self, value):
         """ Process value to be used in catalog query
         """
+        # select2 send us selected values separated by a comma
+        if ',' in value:
+            value = value.split(',')
         if isinstance(value, (tuple, list)):
             value = self.normalize_list(value)
         elif isinstance(value, (str, unicode)):

--- a/eea/facetednavigation/widgets/autocomplete/widget.py
+++ b/eea/facetednavigation/widgets/autocomplete/widget.py
@@ -186,6 +186,6 @@ class SolrSuggest(BrowserView):
         suggestion = root.xpath("//arr[@name='suggestion']")
         if len(suggestion):
             suggestions = suggestion[0].findall('str')
-            result = [{'label': s.text, 'value': s.text} for s in suggestions]
+            result = [{'id': s.text, 'text': s.text} for s in suggestions]
 
         return json.dumps(result)

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(name=NAME,
           # -*- Extra requirements: -*-
           'eea.faceted.vocabularies > 5.2',
           'collective.js.jqueryui',
-          'eea.jquery',
+          'eea.jquery >= 8.7',
           'Products.PloneTestCase',
       ],
       entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(name=NAME,
           # -*- Extra requirements: -*-
           'eea.faceted.vocabularies > 5.2',
           'collective.js.jqueryui',
-          'eea.jquery >= 8.7',
+          'eea.jquery > 8.6',
           'Products.PloneTestCase',
       ],
       entry_points="""


### PR DESCRIPTION
Instead of old jquery.autocomplete, use select2 for the autocomplete widget.
The widget now supports multi values. I added a multivalued option to the widget.

I upgraded select2 to 3.5.4 and added select2 locale files in eea.jquery too.