### PR TITLE
With jquery 1.9 theres no more jquery.browser.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,9 @@ Changelog
 
 8.9.dev0 - (unreleased)
 -----------------------
+* Bug fix: With jquery 1.9 theres no more jquery.browser, remove the usage
+  of it.
+  [pcdummy]
 
 8.8 - (2016-03-01)
 ------------------

--- a/eea/facetednavigation/browser/javascript/view.js
+++ b/eea/facetednavigation/browser/javascript/view.js
@@ -383,9 +383,6 @@ Faceted.AjaxLook = {
     var widget = jQuery('#' + wid + '_widget');
     if(widget.length){
       widget.addClass('faceted-widget-loading');
-      if(jQuery.browser.msie){
-        widget.addClass('faceted-widget-loading-msie');
-      }
     }
   },
 
@@ -402,7 +399,6 @@ Faceted.AjaxLook = {
     var widget = jQuery('#' + wid + '_widget');
     if(widget.length){
       widget.removeClass('faceted-widget-loading');
-      widget.removeClass('faceted-widget-loading-msie');
     }
     this.unlock();
   },

--- a/eea/facetednavigation/browser/stylesheets/view.css
+++ b/eea/facetednavigation/browser/stylesheets/view.css
@@ -202,9 +202,6 @@
   background-repeat:no-repeat;
 }
 
-.faceted-widget-loading-msie {
-  background-position: 95% 2.5em;
-}
 /* Errors
 ========= */
 .faceted-widget-error {


### PR DESCRIPTION
We use for jQuery 1.9, this fixes the usage of it as theres no more jquery.browser in jQuery 1.9.

**I'm not this adds a regression for IE** and currently i don't have an IE to test it.

Signed-off-by: Rene Jochum <rene@jochums.at>