### PR TITLE
Bug fix for autocomplete widget 'multivalued' parameter

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,10 @@ Changelog
 * Bug fix: With jquery 1.9 theres no more jquery.browser, remove the usage
   of it.
   [pcdummy]
+* Bug fix: With autocomplete select2 widget, when data value is imported, it is
+  stored as '1' and not True, take this into account in the widget because '1'
+  is not the same as true for javascript.
+  [gbastien]
 
 8.8 - (2016-03-01)
 ------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,9 +9,9 @@ Changelog
 * Bug fix: With jquery 1.9 theres no more jquery.browser, remove the usage
   of it.
   [pcdummy]
-* Bug fix: With autocomplete select2 widget, when data value is imported, it is
-  stored as '1' and not True, take this into account in the widget because '1'
-  is not the same as true for javascript.
+* Bug fix: With autocomplete select2 widget, when data value for 'multivalued'
+  is imported, it is stored as '1' and not as 'True', take this into account
+  in the widget, we may not use the stored value immediately.
   [gbastien]
 
 8.8 - (2016-03-01)

--- a/eea/facetednavigation/exportimport/criterion.py
+++ b/eea/facetednavigation/exportimport/criterion.py
@@ -62,7 +62,6 @@ class CriterionXMLAdapter(XMLAdapterBase):
                 if element.nodeName != 'element':
                     continue
                 elements.append(element.getAttribute('value').encode('utf-8'))
-
             if elements:
                 properties[key] = elements
             else:

--- a/eea/facetednavigation/exportimport/criterion.py
+++ b/eea/facetednavigation/exportimport/criterion.py
@@ -62,6 +62,7 @@ class CriterionXMLAdapter(XMLAdapterBase):
                 if element.nodeName != 'element':
                     continue
                 elements.append(element.getAttribute('value').encode('utf-8'))
+
             if elements:
                 properties[key] = elements
             else:

--- a/eea/facetednavigation/widgets/autocomplete/widget.pt
+++ b/eea/facetednavigation/widgets/autocomplete/widget.pt
@@ -12,7 +12,7 @@
   tal:attributes="
     id string:${wid}_widget; class css;
     data-autocomplete-view view/autocomplete_view;
-    data-multiple python:getattr(view.data, 'multivalued', True) in ('1', True) and 'true' or 'false';">
+    data-multiple python:getattr(view.data, 'multivalued', True) and 'true' or 'false';">
 
 <fieldset class="widget-fieldset"
   tal:define="title python:view.data.get('title', '')">

--- a/eea/facetednavigation/widgets/autocomplete/widget.pt
+++ b/eea/facetednavigation/widgets/autocomplete/widget.pt
@@ -12,8 +12,7 @@
   tal:attributes="
     id string:${wid}_widget; class css;
     data-autocomplete-view view/autocomplete_view;
-    data-multiple python:str(getattr(view.data, 'multivalued', True)).lower();
-">
+    data-multiple python:getattr(view.data, 'multivalued', True) in ('1', True) and 'true' or 'false';">
 
 <fieldset class="widget-fieldset"
   tal:define="title python:view.data.get('title', '')">

--- a/eea/facetednavigation/widgets/autocomplete/widget.pt
+++ b/eea/facetednavigation/widgets/autocomplete/widget.pt
@@ -12,7 +12,7 @@
   tal:attributes="
     id string:${wid}_widget; class css;
     data-autocomplete-view view/autocomplete_view;
-    data-multiple python:getattr(view.data, 'multivalued', True) and 'true' or 'false';">
+    data-multiple python:'true' if getattr(view.data, 'multivalued', True) else 'false';">
 
 <fieldset class="widget-fieldset"
   tal:define="title python:view.data.get('title', '')">


### PR DESCRIPTION
Hi @avoinea @alecghica 

this is a little bugfix for the automcomplete select2 widget, when imported using GS xml, the value stored in the data for 'multivalued' is empty ('') or '1', when it is '1', it was not working because we used it as value for the select2 JS 'multivalued' parameter, it is expected true/false.

Now, if we have '1' or True, it will be 'true'.

Could you please review and merge?

Thank you!

Gauthier