### PR TITLE
Make it work in Archetypes free environments

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,8 @@ Changelog
 
 10.1.dev0 - (unreleased)
 ------------------------
+* Change: Make it work in a completly Archetypes free Plone 5.1.
+  [jensens]
 
 10.0 - (2016-10-23)
 -------------------

--- a/eea/facetednavigation/caching/configure.zcml
+++ b/eea/facetednavigation/caching/configure.zcml
@@ -1,4 +1,5 @@
-<configure xmlns="http://namespaces.zope.org/zope">
+<configure xmlns="http://namespaces.zope.org/zope"
+           xmlns:zcml="http://namespaces.zope.org/zcml">
 
   <subscriber
     for="..interfaces.IFacetedNavigable
@@ -7,6 +8,7 @@
     />
 
   <subscriber
+    zcml:condition="installed Products.Archetypes"
     for="Products.Archetypes.interfaces.IBaseContent
          zope.lifecycleevent.interfaces.IObjectModifiedEvent"
     handler=".cache.invalidateFacetedCache"

--- a/eea/facetednavigation/configure.zcml
+++ b/eea/facetednavigation/configure.zcml
@@ -24,7 +24,7 @@
   </class>
 
   <class class="plone.app.folder.folder.ATFolder"
-    zcml:condition="installed plone.app.folder">
+    zcml:condition="installed Products.ATContentTypes">
     <implements interface="eea.facetednavigation.interfaces.IPossibleFacetedNavigable" />
   </class>
 

--- a/eea/facetednavigation/search/catalog.py
+++ b/eea/facetednavigation/search/catalog.py
@@ -5,10 +5,18 @@ from zope.event import notify
 from zope.interface import implementer
 from Products.CMFCore.utils import getToolByName
 from BTrees.IIBTree import IIBucket
-from plone.app.collection.interfaces import ICollection
 from eea.facetednavigation.events import QueryWillBeExecutedEvent
 from eea.facetednavigation.search.interfaces import IFacetedCatalog
 from eea.facetednavigation.plonex import parseFormquery
+from zope.interface import Interface
+
+try:
+    from plone.app.collection.interfaces import ICollection
+except ImportError:
+
+    class ICollection(Interface):
+        pass
+
 
 try:
     from plone.app.contenttypes import interfaces as PACI

--- a/eea/facetednavigation/widgets/resultsfilter/widget.py
+++ b/eea/facetednavigation/widgets/resultsfilter/widget.py
@@ -2,7 +2,7 @@
 """
 import logging
 from zope.interface import implementer
-from Products.Archetypes.interfaces import IBaseObject
+from zope.interface import Interface
 from Products.CMFCore.utils import getToolByName
 from eea.facetednavigation.widgets import TrustedEngine
 from eea.facetednavigation.widgets import TrustedZopeContext
@@ -15,6 +15,13 @@ from eea.facetednavigation.widgets.resultsfilter.interfaces import (
     LayoutSchemata,
 )
 logger = logging.getLogger('eea.facetednavigation.widgets.resultsfilter')
+
+try:
+    from Products.Archetypes.interfaces import IBaseObject
+except ImportError:
+
+    class IBaseObject(Interface):
+        pass
 
 
 @implementer(IResultsFilterWidget)

--- a/eea/facetednavigation/widgets/sorting/widget.py
+++ b/eea/facetednavigation/widgets/sorting/widget.py
@@ -5,13 +5,18 @@ from plone.registry.interfaces import IRegistry
 from zope.component import getUtility
 
 from Products.CMFCore.utils import getToolByName
-from Products.ATContentTypes.criteria import _criterionRegistry
 
 from eea.facetednavigation.widgets import ViewPageTemplateFile
 from eea.facetednavigation.widgets.sorting.interfaces import DefaultSchemata
 from eea.facetednavigation.widgets.sorting.interfaces import LayoutSchemata
 from eea.facetednavigation.widgets.widget import Widget as AbstractWidget
 from eea.facetednavigation import EEAMessageFactory as _
+
+try:
+    from Products.ATContentTypes.criteria import _criterionRegistry
+    HAS_ATCT = True
+except ImportError:
+    HAS_ATCT = False
 
 
 class Widget(AbstractWidget):
@@ -62,6 +67,8 @@ class Widget(AbstractWidget):
 
     def criteriaByIndexId(self, indexId):
         """ Get criteria by index id
+
+        XXX: this method is probaly orphaned code
         """
         catalog_tool = getToolByName(self.context, 'portal_catalog')
         try:
@@ -79,8 +86,12 @@ class Widget(AbstractWidget):
 
     def validateAddCriterion(self, indexId, criteriaType):
         """Is criteriaType acceptable criteria for indexId
+
+        XXX: this method is probaly orphaned code
         """
-        return criteriaType in self.criteriaByIndexId(indexId)
+        if HAS_ATCT:
+            return criteriaType in self.criteriaByIndexId(indexId)
+        return True
 
     def listSortFields(self):
         """Return a list of available fields for sorting."""

--- a/eea/facetednavigation/widgets/tal/widget.py
+++ b/eea/facetednavigation/widgets/tal/widget.py
@@ -2,7 +2,7 @@
 """
 # Python
 import logging
-from Products.Archetypes.interfaces import IBaseObject
+from zope.interface import Interface
 from Products.CMFCore.utils import getToolByName
 from eea.facetednavigation.widgets import ViewPageTemplateFile
 from eea.facetednavigation.widgets import TrustedEngine
@@ -12,6 +12,13 @@ from eea.facetednavigation.widgets.tal.interfaces import LayoutSchemata
 from eea.facetednavigation.widgets.widget import Widget as AbstractWidget
 from eea.facetednavigation import EEAMessageFactory as _
 logger = logging.getLogger('eea.facetednavigation.widgets.tal')
+
+try:
+    from Products.Archetypes.interfaces import IBaseObject
+except ImportError:
+
+    class IBaseObject(Interface):
+        pass
 
 
 class Widget(AbstractWidget):


### PR DESCRIPTION
My new projects are now Archetypes free Plone 5.1 setups. 

There were some traces of AT left in eea.facetednavigation, which are now made conditional.

At one place I found probably dead/orphaned code (widgets/sorting/widgets.py). We may want to remove the two methods completely, but I may have overseen some usage.