### PR TITLE
Do not use a name to query the solr search utility

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,9 +3,11 @@ Changelog
 
 10.1.dev2 - (unreleased)
 ------------------------
-* Bug fix: Updated to previous change: restored replace of 'term.' in 
+* Bug fix: Updated to previous change: restored replace of 'term.' in
   vocabulary id for Products.ATVocabularyManager compatibility.
   [tsimkins]
+* Bug fix: Do not use a name to query collective.solr search utility
+  [tschorr]
 
 10.1.dev1 - (unreleased)
 ------------------------

--- a/eea/facetednavigation/widgets/widget.py
+++ b/eea/facetednavigation/widgets/widget.py
@@ -244,7 +244,7 @@ class Widget(GroupForm, Form):
             values = []
 
             # get values from SOLR if collective.solr is present
-            searchutility = queryUtility(ISolrSearch, None)
+            searchutility = queryUtility(ISolrSearch)
             if searchutility is not None:
                 index = self.data.get('index', None)
                 kw = {'facet': 'on',


### PR DESCRIPTION
The utility is unnamed. See https://github.com/zopefoundation/zope.interface/pull/75 for consequences of using `None` as a name.