### PR TITLE
Bug fix: make sure orphans used in FacetedQueryHandler.query is an integer when using Py3 or it turns b_size to a float value that breaks plone.batching

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,10 @@ Changelog
 
 13.8-dev0 - (unreleased)
 ---------------------------
+* Bug fix: make sure orphans used in FacetedQueryHandler.query is an integer
+  when using Py3 or it turns b_size to a float value that breaks plone.batching
+  Fixes https://github.com/eea/eea.facetednavigation/issues/197
+  [gbastien]
 
 13.7 - (2020-01-19)
 ---------------------------

--- a/eea/facetednavigation/browser/app/query.py
+++ b/eea/facetednavigation/browser/app/query.py
@@ -168,7 +168,9 @@ class FacetedQueryHandler(FolderView):
                 brains_filters.append(brains_filter)
 
         b_start = safeToInt(kwargs.get('b_start', 0))
-        orphans = num_per_page * 20 / 100 # orphans = 20% of items per page
+        # make sure orphans is an integer, // is used so in Python3 we have an
+        # integer division as by default, a division result is a float
+        orphans = num_per_page * 20 // 100  # orphans = 20% of items per page
         if batch and not brains_filters:
             # add b_start and b_size to query to use better sort algorithm
             query['b_start'] = b_start


### PR DESCRIPTION
Hi @avoinea 

this is a PR that will fix #197 

Thank you for review and merge ;-)

Gauthier