### PR TITLE
Separate criterion counter

### DIFF
--- a/eea/facetednavigation/widgets/checkbox/view.js
+++ b/eea/facetednavigation/widgets/checkbox/view.js
@@ -204,7 +204,7 @@ Faceted.CheckboxesWidget.prototype = {
       var value = element.val();
       var label = jQuery('label[for=' + id + ']', widget.widget);
       var title = label.attr('title');
-      label = label.text();
+      var count = label.children('span').text();
 
       var link = jQuery('<a href="#" class="faceted-remove">remove</a>');
       link.attr('id', 'criteria_' + id);
@@ -215,7 +215,8 @@ Faceted.CheckboxesWidget.prototype = {
       });
 
       span.append(link);
-      jQuery('<span>').text(label).appendTo(span);
+      jQuery('<span class="title">').text(title).appendTo(span);
+      jQuery('<span class="count">').text(count).appendTo(span);
       html.append(span);
     });
 


### PR DESCRIPTION
This splits the "title" and the "counter" into different span tags, so its easy to style or hide.

Before:
![eea_before](https://user-images.githubusercontent.com/48724/137783294-b8ebaba5-1ebc-45cb-bcf5-14ed44f64179.png)

After:
![eea_after](https://user-images.githubusercontent.com/48724/137783316-a3dc3c10-a5e4-441d-bc16-102f0db13313.png)

